### PR TITLE
[ADD]BackgroundCard 컴포넌트 추가

### DIFF
--- a/src/Common/BackgroundCard.tsx
+++ b/src/Common/BackgroundCard.tsx
@@ -1,0 +1,35 @@
+import styled, { css } from "styled-components";
+
+interface Props {
+    color: string;
+    height: string;
+    translateX: string;
+    translateY: string;
+    type: 'bordered' | 'filled';
+
+}
+
+const BackgroundCard = styled.div<Props>`
+    position: absolute;
+    left: 0;
+    width: 100vw;
+    height: ${props => props.height};
+    border-radius: 2rem;
+    z-index: -3;
+    ${props => css`transform: translate(${props.translateX}, ${props.translateY});`}
+    ${props => {
+        switch(props.type) {
+            case 'bordered':
+                return css`
+                    border: 1rem solid;
+                    border-color: ${props.color};
+                `;
+            case 'filled':
+                return css`
+                    background-color: ${props.color};
+                `;
+        }
+    }}
+`;
+
+export default BackgroundCard;


### PR DESCRIPTION
# Summary
페이지 디자인에 사용 될 사각형 모양의 컴포넌트를 추가했습니다.
# Description
## Example
```typescript
import BackgroundCard from "../../src/Common/BackgroundCard";
```
```html
<BackgroundCard 
    color="#004477"  <!--카드 색상 코드-->
    height="18rem" <!--카드 높이-->
    translateX="-40%" <!--가로 위치(중앙 : 0)-->
    translateY="50%" <!--세로 위치(중앙 : 0)-->
    type="filled" <!--유형(bordered | filled)-->
/>
```
## Result
<img width="1440" alt="Screen Shot 2022-12-29 at 4 44 16 PM" src="https://user-images.githubusercontent.com/10252712/209919762-befb7ec7-2877-4c13-9e7e-e43d3122db35.png">