### PR TITLE
Main 페이지에 Rectangle 디자인 추가

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -55,6 +55,7 @@ const HistoryTitle = styled.div`
     text-align: right;
     font-size: 55pt;
     letter-spacing: -7px;
+    color: #fff;
   }
 `;
 

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
 import Link from "next/link";
 import Dbutton from "../../src/Common/Dbutton";
+import MainRectangle from "./MainRectangle";
 
 const MainHistory = () => {
   return (
+    <>
+    <MainRectangle/>
     <MainHistoryWrapper>
       <HistoryTitle>
         <h1>
@@ -45,6 +48,7 @@ const MainHistory = () => {
           </HistoryButton>
       </HistoryContents>
     </MainHistoryWrapper>
+    </>
   );
 };
 

--- a/pages/Main/MainRectangle.tsx
+++ b/pages/Main/MainRectangle.tsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+import BackgroundCard from "../../src/Common/BackgroundCard";
+
+const MainRectangle = () => {
+    return(
+        <>
+        </>
+    );
+};
+
+export default MainRectangle;

--- a/pages/Main/MainRectangle.tsx
+++ b/pages/Main/MainRectangle.tsx
@@ -5,7 +5,7 @@ import BackgroundCard from "../../src/Common/BackgroundCard";
 //     height: string;
 //     translateX: string;
 //     translateY: string;
-//     type: 'bordered' | 'filled';
+//     type: 'bordered' | 'filled' -> string;
 
 const mainRectangle = [
   {

--- a/pages/Main/MainRectangle.tsx
+++ b/pages/Main/MainRectangle.tsx
@@ -14,7 +14,7 @@ const mainRectangle = [
     height: "22rem",
     tranX: "-78rem",
     tranY: "7rem",
-    type: "bordered"
+    typeR: "bordered",
   },
   {
     id: "r2",
@@ -22,7 +22,7 @@ const mainRectangle = [
     height: "22rem",
     tranX: "60rem",
     tranY: "27rem",
-    type: "filled"
+    typeR: "filled",
   },
   {
     id: "r3",
@@ -30,7 +30,7 @@ const mainRectangle = [
     height: "22rem",
     tranX: "61rem",
     tranY: "76rem",
-    type: "filled"
+    typeR: "filled",
   },
   {
     id: "r4",
@@ -38,7 +38,7 @@ const mainRectangle = [
     height: "22rem",
     tranX: "59rem",
     tranY: "71rem",
-    type: "filled"
+    typeR: "filled",
   },
   {
     id: "r5",
@@ -46,7 +46,7 @@ const mainRectangle = [
     height: "22rem",
     tranX: "-78rem",
     tranY: "105.6rem",
-    type: "bordered"
+    typeR: "bordered",
   },
   {
     id: "r6",
@@ -54,7 +54,7 @@ const mainRectangle = [
     height: "22rem",
     tranX: "-78rem",
     tranY: "143rem",
-    type: "bordered"
+    typeR: "bordered",
   },
   {
     id: "r7",
@@ -62,69 +62,23 @@ const mainRectangle = [
     height: "22rem",
     tranX: "59rem",
     tranY: "160rem",
-    type: "bordered"
+    typeR: "bordered",
   },
 ];
 
 const MainRectangle = () => {
   return (
     <>
-      {}
-      <BackgroundCard
-        color={"#35B6F7"}
-        height={"22rem"}
-        translateX={"-78rem"}
-        translateY={"7rem"}
-        type={"bordered"}
-      />
-
-      <BackgroundCard
-        color={"#C7E7FF"}
-        height={"22rem"}
-        translateX={"60rem"}
-        translateY={"27rem"}
-        type={"filled"}
-      />
-
-      <BackgroundCard
-        color={"#35B6F7"}
-        height={"22rem"}
-        translateX={"61rem"}
-        translateY={"76rem"}
-        type={"filled"}
-      />
-
-      <BackgroundCard
-        color={"#00658F"}
-        height={"22rem"}
-        translateX={"59rem"}
-        translateY={"71rem"}
-        type={"filled"}
-      />
-
-      <BackgroundCard
-        color={"#00658F"}
-        height={"22rem"}
-        translateX={"-78rem"}
-        translateY={"105.6rem"}
-        type={"bordered"}
-      />
-
-      <BackgroundCard
-        color={"#C7E7FF"}
-        height={"22rem"}
-        translateX={"-78rem"}
-        translateY={"143rem"}
-        type={"bordered"}
-      />
-
-      <BackgroundCard
-        color={"#35B6F7"}
-        height={"22rem"}
-        translateX={"59rem"}
-        translateY={"160rem"}
-        type={"bordered"}
-      />
+      {mainRectangle.map((items) => (
+        <BackgroundCard
+          key={items.id}
+          color={items.color}
+          height={items.height}
+          translateX={items.tranX}
+          translateY={items.tranY}
+          type={items.typeR}
+        />
+      ))}
     </>
   );
 };

--- a/pages/Main/MainRectangle.tsx
+++ b/pages/Main/MainRectangle.tsx
@@ -12,7 +12,7 @@ const MainRectangle = () => {
     <>
       <BackgroundCard
         color={"#35B6F7"}
-        height={"20rem"}
+        height={"22rem"}
         translateX={"-78rem"}
         translateY={"7rem"}
         type={"bordered"}
@@ -20,7 +20,7 @@ const MainRectangle = () => {
 
       <BackgroundCard
         color={"#C7E7FF"}
-        height={"20rem"}
+        height={"22rem"}
         translateX={"60rem"}
         translateY={"27rem"}
         type={"filled"}
@@ -28,18 +28,42 @@ const MainRectangle = () => {
 
       <BackgroundCard
         color={"#35B6F7"}
-        height={"20rem"}
-        translateX={"62rem"}
-        translateY={"73rem"}
+        height={"22rem"}
+        translateX={"61rem"}
+        translateY={"76rem"}
         type={"filled"}
       />
-      
+
       <BackgroundCard
         color={"#00658F"}
-        height={"20rem"}
-        translateX={"60rem"}
-        translateY={"70rem"}
+        height={"22rem"}
+        translateX={"59rem"}
+        translateY={"71rem"}
         type={"filled"}
+      />
+
+      <BackgroundCard
+        color={"#00658F"}
+        height={"22rem"}
+        translateX={"-78rem"}
+        translateY={"105.6rem"}
+        type={"bordered"}
+      />
+
+      <BackgroundCard
+        color={"#C7E7FF"}
+        height={"22rem"}
+        translateX={"-78rem"}
+        translateY={"143rem"}
+        type={"bordered"}
+      />
+
+      <BackgroundCard
+        color={"#35B6F7"}
+        height={"22rem"}
+        translateX={"59rem"}
+        translateY={"160rem"}
+        type={"bordered"}
       />
     </>
   );

--- a/pages/Main/MainRectangle.tsx
+++ b/pages/Main/MainRectangle.tsx
@@ -7,9 +7,69 @@ import BackgroundCard from "../../src/Common/BackgroundCard";
 //     translateY: string;
 //     type: 'bordered' | 'filled';
 
+const mainRectangle = [
+  {
+    id: "r1",
+    color: "#35B6F7",
+    height: "22rem",
+    tranX: "-78rem",
+    tranY: "7rem",
+    type: "bordered"
+  },
+  {
+    id: "r2",
+    color: "#C7E7FF",
+    height: "22rem",
+    tranX: "60rem",
+    tranY: "27rem",
+    type: "filled"
+  },
+  {
+    id: "r3",
+    color: "#35B6F7",
+    height: "22rem",
+    tranX: "61rem",
+    tranY: "76rem",
+    type: "filled"
+  },
+  {
+    id: "r4",
+    color: "#00658F",
+    height: "22rem",
+    tranX: "59rem",
+    tranY: "71rem",
+    type: "filled"
+  },
+  {
+    id: "r5",
+    color: "#00658F",
+    height: "22rem",
+    tranX: "-78rem",
+    tranY: "105.6rem",
+    type: "bordered"
+  },
+  {
+    id: "r6",
+    color: "#C7E7FF",
+    height: "22rem",
+    tranX: "-78rem",
+    tranY: "143rem",
+    type: "bordered"
+  },
+  {
+    id: "r7",
+    color: "#35B6F7",
+    height: "22rem",
+    tranX: "59rem",
+    tranY: "160rem",
+    type: "bordered"
+  },
+];
+
 const MainRectangle = () => {
   return (
     <>
+      {}
       <BackgroundCard
         color={"#35B6F7"}
         height={"22rem"}

--- a/pages/Main/MainRectangle.tsx
+++ b/pages/Main/MainRectangle.tsx
@@ -1,11 +1,48 @@
 import styled from "styled-components";
 import BackgroundCard from "../../src/Common/BackgroundCard";
 
+// color: string;
+//     height: string;
+//     translateX: string;
+//     translateY: string;
+//     type: 'bordered' | 'filled';
+
 const MainRectangle = () => {
-    return(
-        <>
-        </>
-    );
+  return (
+    <>
+      <BackgroundCard
+        color={"#35B6F7"}
+        height={"20rem"}
+        translateX={"-78rem"}
+        translateY={"7rem"}
+        type={"bordered"}
+      />
+
+      <BackgroundCard
+        color={"#C7E7FF"}
+        height={"20rem"}
+        translateX={"60rem"}
+        translateY={"27rem"}
+        type={"filled"}
+      />
+
+      <BackgroundCard
+        color={"#35B6F7"}
+        height={"20rem"}
+        translateX={"62rem"}
+        translateY={"73rem"}
+        type={"filled"}
+      />
+      
+      <BackgroundCard
+        color={"#00658F"}
+        height={"20rem"}
+        translateX={"60rem"}
+        translateY={"70rem"}
+        type={"filled"}
+      />
+    </>
+  );
 };
 
 export default MainRectangle;

--- a/pages/Main/MainWorks.tsx
+++ b/pages/Main/MainWorks.tsx
@@ -54,13 +54,14 @@ const MainWorks = () => {
 };
 
 const MainWorksWrapper = styled.div`
-  height: 80vh;
+  height: 100vh;
+	margin-top : 100px;
 `;
 
 const WorksTitle = styled.div`
   display: flex;
   flex-direction: column;
-	margin: 0rem 0rem 5rem 22rem;
+	margin: 200px 0px 50px 350px;
 
 	h1 {
     text-align: left;
@@ -76,7 +77,7 @@ const WorksTitle = styled.div`
 `;
 
 const ScrollMenuWrapper = styled.div`
-	margin: 0rem 22rem 0rem 22rem;
+	margin: 0px 330px 0px 300px;
 `
 
 

--- a/src/Common/BackgroundCard.tsx
+++ b/src/Common/BackgroundCard.tsx
@@ -5,7 +5,7 @@ interface Props {
     height: string;
     translateX: string;
     translateY: string;
-    type: 'bordered' | 'filled';
+    type: string;
 
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -72,6 +72,10 @@
     --card-rgb: 100, 100, 100;
     --card-border-rgb: 200, 200, 200;
   }
+
+  body{
+    color: #FFFFFF;
+  }
 }
 
 * {


### PR DESCRIPTION
# Summary
- @rdg1029 제작의 BackgroundCard 컴포넌트를 활용하여 Main 페이지에 Rectangle 디자인 요소 추가
- 지난 PR에서 제기되었던 문제인 MainWorks 컴포넌트의 Margin 단위 이슈 해결

# Description
- BackgroundCard 컴포넌트의 Props 중 type의 형을 'bordered' || 'filled' 에서 string으로 수정
- MainRectangle 컴포넌트에 Main 페이지에 들어갈 Rectangle들이 가져야할 속성으로 이루어진 배열을 정의하여 BackgroundCard 컴포넌트를 리스트 렌더링하여 구현하였음.
- MainRectangle 컴포넌트의 BackgroundCard의 단위는 동적이어야 하므로 rem을 사용하였으나 테스트 배포시 문제 발생하면 변경해야할 소지가 있음.

# Image
![screencapture-localhost-3000-2022-12-31-21_33_44](https://user-images.githubusercontent.com/47844901/210136904-a31b36e4-168f-4bac-a9ba-b54704c5a2c6.png)
