### PR TITLE
[FIX] Project List 관련 빌드 오류 수정

### DIFF
--- a/pages/Projects/ProjectList.tsx
+++ b/pages/Projects/ProjectList.tsx
@@ -9,7 +9,7 @@ interface Props {
 const ProjectList = (props: Props) => {
   return (
     <ScrollMenu>
-      {props.list.map((item, i) => {
+      {props.list && props.list.map((item, i) => {
         return <ProjectListItem key={i} id={item.id} image={item.data.image[0]} title={item.data.title} />
       })}
     </ScrollMenu>


### PR DESCRIPTION
# Summary
`TypeError: Cannot read properties of undefined (reading 'map')`
빌드를 할 때 리스트에서 map 속성을 찾지 못하는 오류를 수정했습니다.
# ScreenShot
이렇게 나오면 빌드 잘 된거 맞죠?
<img width="799" alt="스크린샷 2023-01-22 오전 8 49 40" src="https://user-images.githubusercontent.com/10252712/213894530-754941e3-865a-47d9-8203-eac18e93fe7a.png">