### PR TITLE
[UPDATE] Members 페이지 부가 디자인 요소 적용

### DIFF
--- a/pages/Members/Members.tsx
+++ b/pages/Members/Members.tsx
@@ -48,7 +48,7 @@ const Members = () => {
     return (
         <MembersStyle>
             <MembersContainer>
-                <MembersRectangle/>
+                {isFirstClicked && <MembersRectangle/> }
                 <MembersTitle />
                 <MembersViewContainer>
                     <MembersList memberData={memberList} onClick={onMemberClick}/>

--- a/pages/Members/Members.tsx
+++ b/pages/Members/Members.tsx
@@ -7,6 +7,10 @@ import MembersList from "./MembersList";
 import MembersDetail from "./MembersDetail";
 import MembersRectangle from "./MembersRectangle";
 
+interface Props{
+    marginBotton: boolean;
+};
+
 const tmpMemberData: MemberData = {
     id: "",
     data: {
@@ -46,7 +50,7 @@ const Members = () => {
     }
 
     return (
-        <MembersStyle>
+        <MembersStyle marginBotton={isFirstClicked}>
             <MembersContainer>
                 {isFirstClicked && <MembersRectangle/> }
                 <MembersTitle />
@@ -59,13 +63,15 @@ const Members = () => {
     );
 };
 
-const MembersStyle = styled.div`
+const MembersStyle = styled.div<Props>`
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
   
     font-family: "Noto Sans KR";
+
+    margin-bottom: ${props => props.marginBotton && '50vh'};
 `;
 
 const MembersContainer = styled.div`

--- a/pages/Members/MembersListItem.tsx
+++ b/pages/Members/MembersListItem.tsx
@@ -103,6 +103,12 @@ const MemberItemContainer = styled.div`
   
     display: flex;
     flex-direction: row;
+
+    border-radius: 0px 20px 20px 0px;
+
+    :hover{
+        box-shadow: 0px 5px 5px #00658F;
+    }
 `;
 
 const MemberItemImageContainer = styled.div`

--- a/pages/Members/MembersRectangle.tsx
+++ b/pages/Members/MembersRectangle.tsx
@@ -1,10 +1,6 @@
 import BackgroundCard from "../../src/Common/BackgroundCard";
 
-interface Props{
-    width: string;
-}
-
-const MainRectangle = (props : Props) => {
+const MainRectangle = () => {
     return (
         <BackgroundCard
             key="MembersRectangle"

--- a/pages/Members/MembersRectangle.tsx
+++ b/pages/Members/MembersRectangle.tsx
@@ -1,16 +1,22 @@
 import BackgroundCard from "../../src/Common/BackgroundCard";
 
-const MainRectangle = () => {
+interface Props{
+    width: string;
+}
+
+const MainRectangle = (props : Props) => {
     return (
         <BackgroundCard
             key="MembersRectangle"
             color="#35B6F7"
-            height="50rem"
-            translateX="300px"
+            width="50rem"
+            height="80rem"
+            translateX="900px"
             translateY="250px"
             type="bordered"
         />
     );
 };
+
 
 export default MainRectangle;

--- a/pages/Members/MembersRectangle.tsx
+++ b/pages/Members/MembersRectangle.tsx
@@ -5,8 +5,8 @@ const MainRectangle = () => {
         <BackgroundCard
             key="MembersRectangle"
             color="#35B6F7"
-            height="430px"
-            translateX="1300px"
+            height="50rem"
+            translateX="300px"
             translateY="250px"
             type="bordered"
         />

--- a/src/Common/BackgroundCard.tsx
+++ b/src/Common/BackgroundCard.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import React from "react";
 
 interface Props {
   color: string;
@@ -7,35 +8,51 @@ interface Props {
   translateX: string;
   translateY: string;
   type: string;
-
 }
 
-const BackgroundCard = styled.div<Props>`
+const BackgroundCard = (props: Props) => {
+  return (
+    <>
+      <CardStyled
+        color={props.color}
+        width={props.width}
+        height={props.height}
+        translateX={props.translateX}
+        translateY={props.translateY}
+        type={props.type}
+      />
+    </>
+  );
+};
+
+const CardStyled = styled.div<Props>`
   position: absolute;
   left: 0;
-  width: ${props => props.width};
-  height: ${props => props.height};
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
   border-radius: 2rem;
   z-index: -3;
-  ${props => css`transform: translate(${props.translateX}, ${props.translateY});`}
-  ${props => {
+  ${(props) =>
+    css`
+      transform: translate(${props.translateX}, ${props.translateY});
+    `}
+  ${(props) => {
     switch (props.type) {
-      case 'bordered':
+      case "bordered":
         return css`
           border: 1rem solid;
           border-color: ${props.color};
         `;
-      case 'filled':
+      case "filled":
         return css`
           background-color: ${props.color};
-      `;
+        `;
     }
   }}
 `;
 
 BackgroundCard.defaultProps = {
-  width: '100vw'
+  width: "100vw",
 };
-
 
 export default BackgroundCard;

--- a/src/Common/BackgroundCard.tsx
+++ b/src/Common/BackgroundCard.tsx
@@ -2,6 +2,7 @@ import styled, { css } from "styled-components";
 
 interface Props {
   color: string;
+  width: string;
   height: string;
   translateX: string;
   translateY: string;
@@ -12,7 +13,7 @@ interface Props {
 const BackgroundCard = styled.div<Props>`
   position: absolute;
   left: 0;
-  width: 100vw;
+  width: ${props => props.width};
   height: ${props => props.height};
   border-radius: 2rem;
   z-index: -3;
@@ -31,5 +32,10 @@ const BackgroundCard = styled.div<Props>`
     }
   }}
 `;
+
+BackgroundCard.defaultProps = {
+  width: '100vw'
+};
+
 
 export default BackgroundCard;


### PR DESCRIPTION
# Summary
- Members 각 카드 클릭시 Rectangle 박스를 보여줍니다.
- Members 각 카드 마우스 오버시 그림자 효과를 보여줍니다.
- Members 각 카드 클릭시 내용이 보여질 공간을 위해 마진을 부여합니다.

# Description
- Members 카드 클릭시 Rectangle 박스에 CSS 속성 Width를 Props로 부여하기 위해 BackgroundCard.tsx를 단일 styled-component에서 컴포넌트를 함수로 선언하는 것으로 수정하였습니다.
  - defaultProps 속성을 선언하여 width가 Props를 통해 넘겨지지 않을 시에는 기존과 동일한 width를 유지하도록 했습니다.
- 위에서 수정한 BackgroundCard 컴포넌트에 width 속성을 Props로 넘겨주어 멤버 디테일을 보여줄 박스를 보여줍니다.
  - 이 박스는 isFirstClicked를 이름으로 갖는 Bool 타입 State의 상태에 따라 보여줄지 말지 결정됩니다. 
- :hover에 Box-Shadow 속성을 추가하여 마우스 오버시 그림자 효과를 보여줍니다. 그림자의 색상은 이번 웹의 메인 테마 색상으로 설정했습니다.
- 멤버 별 각 카드 클릭시 내용 및 박스가 보여질 공간을 위해 isFirstClicked State의 상태에 따라 마진을 부여합니다.

# Image
## 전체 이미지
![screencapture-localhost-3000-Members-2023-01-25-00_45_00](https://user-images.githubusercontent.com/47844901/214342650-d44ebc13-8e2e-4bfd-a8cf-98982c3784a4.png)

## 카드 마우스 오버 예시
![스크린샷 2023-01-25 오전 12 46 00](https://user-images.githubusercontent.com/47844901/214342701-6c16c7d9-798b-4c9b-8789-39854245a2a8.png)
