### PR TITLE
[FIX] Member 페이지 디자인 세부사항 개선 완료

### DIFF
--- a/pages/Members/MembersListItem.tsx
+++ b/pages/Members/MembersListItem.tsx
@@ -108,6 +108,7 @@ const MemberItemContainer = styled.div`
 
     :hover{
         box-shadow: 0px 5px 5px #00658F;
+        transition: box-shadow 0.5s ease-in-out;
     }
 `;
 

--- a/pages/Members/MembersRectangle.tsx
+++ b/pages/Members/MembersRectangle.tsx
@@ -8,7 +8,7 @@ const MainRectangle = () => {
             width="50rem"
             height="80rem"
             translateX="48vw"
-            translateY="20vh"
+            translateY="30vh"
             type="bordered"
         />
     );

--- a/pages/Members/MembersRectangle.tsx
+++ b/pages/Members/MembersRectangle.tsx
@@ -7,8 +7,8 @@ const MainRectangle = () => {
             color="#35B6F7"
             width="50rem"
             height="80rem"
-            translateX="900px"
-            translateY="250px"
+            translateX="48vw"
+            translateY="20vh"
             type="bordered"
         />
     );

--- a/pages/Members/MembersTitle.tsx
+++ b/pages/Members/MembersTitle.tsx
@@ -19,15 +19,20 @@ const MembersTitleContainer = styled.div`
 `;
 
 const MembersTitleMain = styled.p`
-    font-size: 45pt;
-    font-weight: 800;
-    line-height: 90px;
+    font-size: 55pt;
+    font-weight: 900;
+    line-height: 60px;
+    letter-spacing: -5px;
+
+    margin-bottom: -20px;
 `;
 
 const MembersTitleSub = styled.p`
-    font-size: 17pt;
-    font-weight: 400;
+    font-size: 20pt;
+    font-weight: 300;
     line-height: 35px;
+
+    margin-bottom: 100px;
 `;
 
 


### PR DESCRIPTION
# Summary
- 요청하신 수정 사항을 반영하였습니다.

# Descriptions
- MembersRectangle의 translate 속성을 viewport 단위로 조정하여 px 단위로 적용했을 때와 동일한 위치를 적용했습니다.
  - width와 height에 사용된 rem 단위는 다시 한 번 테스트 서버 배포 결과를 보고 수정 유무를 판단하고 싶어 유지하였습니다.
- MembersListItem에 적용된 마우스 hover시 box-shadow 속성을 부여하는 효과를 transition 속성을 이용하여 부드럽게 조정하였습니다. (그림자가 생기는 속도가 마음에 안들면 수정하겠습니다.)
- MembersTitle에서 letter-spacing 속성을 부여하여 자간을 조절하였고 line-height 속성을 조정하여 행간을 조절하였습니다.
  - sub title에 font-weight 속성을 300으로 부여하여 Figma 프로토타입과 동일한 디자인 형태를 적용하였습니다.

# Images
![screencapture-localhost-3000-Members-2023-01-25-21_24_15](https://user-images.githubusercontent.com/47844901/214562674-9a44d952-7893-4c5e-becf-3fff0f137730.png)

