### PR TITLE
[UPDATE] 프로젝트 페이지, 멤버 페이지 모바일 UI 적용

### DIFF
--- a/pages/Members/Members.tsx
+++ b/pages/Members/Members.tsx
@@ -52,7 +52,6 @@ const Members = () => {
     return (
         <MembersStyle marginBotton={isFirstClicked}>
             <MembersContainer>
-                {isFirstClicked && <MembersRectangle/> }
                 <MembersTitle />
                 <MembersViewContainer>
                     <MembersList memberData={memberList} onClick={onMemberClick}/>
@@ -76,9 +75,30 @@ const MembersStyle = styled.div<Props>`
 
 const MembersContainer = styled.div`
     height: 100%;
-    width: 1400px;
-  
     margin-top: 150px;
+    @media all and (min-width: 1280px) {
+        width: 1400px;
+    }
+    
+    /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
+    @media all and (min-width:1024px) and (max-width:1279px) {
+        width: 1024px;
+    }   
+    
+    /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
+    @media all and (min-width:768px) and (max-width:1023px) {
+        width: 768px;
+    } 
+    
+    /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+    @media all and (min-width:480px) and (max-width:767px) {
+        width: 480px;
+    } 
+    
+    /* 모바일 세로 (해상도 ~ 479px)*/ 
+    @media all and (max-width:479px) {
+        width: 360px;
+    }
 `;
 
 const MembersViewContainer = styled.div`
@@ -86,9 +106,13 @@ const MembersViewContainer = styled.div`
     width: 100%;
   
     display: flex;
-    flex-direction: row;
     align-items: flex-start;
     justify-content: space-between;
+
+    @media all and (min-width: 1280px) {
+        flex-direction: row;
+    }
+    flex-direction: column;
 `;
 
 export type MemberData = {

--- a/pages/Members/Members.tsx
+++ b/pages/Members/Members.tsx
@@ -1,11 +1,10 @@
-import {useEffect, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import styled from "styled-components";
 
 import * as API from "../../src/Common/API";
 import MembersTitle from "./MembersTitle";
 import MembersList from "./MembersList";
 import MembersDetail from "./MembersDetail";
-import MembersRectangle from "./MembersRectangle";
 
 interface Props{
     marginBotton: boolean;
@@ -35,6 +34,7 @@ const Members = () => {
     const [isFirstClicked, setIsFirstClicked] = useState(false);
     const [memberData, setMemberData] = useState(tmpMemberData);
     const [memberList, setMemberList] = useState(tmpMemberList);
+    const membersDetailRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         API.getMemberList().then((apiResult : any) => {
@@ -46,6 +46,7 @@ const Members = () => {
         setIsFirstClicked(true);
         API.getMemberData(id).then((apiResult : any) => {
             setMemberData({id: id, data: apiResult});
+            membersDetailRef.current?.scrollIntoView({behavior: "smooth"});
         });
     }
 
@@ -55,7 +56,7 @@ const Members = () => {
                 <MembersTitle />
                 <MembersViewContainer>
                     <MembersList memberData={memberList} onClick={onMemberClick}/>
-                    <MembersDetail isFirstClicked={isFirstClicked} memberData={memberData}/>
+                    <MembersDetail ref={membersDetailRef} isFirstClicked={isFirstClicked} memberData={memberData}/>
                 </MembersViewContainer>
             </MembersContainer>
         </MembersStyle>

--- a/pages/Members/MembersDetail.tsx
+++ b/pages/Members/MembersDetail.tsx
@@ -18,7 +18,7 @@ const MembersDetail = React.forwardRef((props: {isFirstClicked: boolean, memberD
                 props.memberData.data.boj.isEnabled ?
                     <MembersDetailBojContainer>
                         <MembersDetailTitle>Solved. ac</MembersDetailTitle>
-                        <Image alt={"BOJ Badge"} src={`https://mazassumnida.wtf/api/v2/generate_badge?boj=${props.memberData.data && props.memberData.data.boj.username}`} width="350" height="175" unoptimized={true} />
+                        <MembersDetailBojImage alt={"BOJ Badge"} src={`https://mazassumnida.wtf/api/v2/generate_badge?boj=${props.memberData.data && props.memberData.data.boj.username}`} width="350" height="175" unoptimized={true} />
                     </MembersDetailBojContainer>
                 : null
             }
@@ -64,6 +64,15 @@ const MembersDetailBojContainer = styled.div`
     align-items: center;
 
     margin: 15px 0;
+`;
+
+const MembersDetailBojImage = styled(Image)`
+    @media all and (max-width:479px) {
+        width: 320px;
+        height: 160px;
+    }
+    width: 350px;
+    height: 175px;
 `;
 
 const MembersDetailCompanyContainer = styled.div`

--- a/pages/Members/MembersDetail.tsx
+++ b/pages/Members/MembersDetail.tsx
@@ -51,6 +51,10 @@ const MembersDetailContainer = styled.div`
     align-items: center;
     
     margin: 30px 0 100px 0;
+
+    border: 1rem solid;
+    border-color: #35B6F7;
+    border-radius: 2rem;
 `;
 
 const MembersDetailBojContainer = styled.div`

--- a/pages/Members/MembersDetail.tsx
+++ b/pages/Members/MembersDetail.tsx
@@ -1,15 +1,16 @@
 import Image from "next/image";
+import React, { RefObject } from "react";
 import styled from "styled-components";
 
 import { MemberData } from "./Members";
 
-const MembersDetail = (props: {isFirstClicked: boolean, memberData: MemberData}) => {
+const MembersDetail = React.forwardRef((props: {isFirstClicked: boolean, memberData: MemberData}, ref: React.ForwardedRef<HTMLDivElement>) => {
     if(!props.isFirstClicked){
         return null;
     }
 
     return (
-        <MembersDetailContainer>
+        <MembersDetailContainer ref={ref}>
             <MembersDetailCompanyContainer>
                 <Image alt={"Company Logo"} src={props.memberData.data && props.memberData.data.company_img} width="200" height="200" unoptimized={true} />
             </MembersDetailCompanyContainer>
@@ -31,7 +32,7 @@ const MembersDetail = (props: {isFirstClicked: boolean, memberData: MemberData})
             </MembersDetailHistoryContainer>
         </MembersDetailContainer>
     );
-};
+});
 
 const MemberDetailHistoryItem = (props: {historyData: {content: string, date: string}}) => {
     return(

--- a/pages/Members/MembersList.tsx
+++ b/pages/Members/MembersList.tsx
@@ -19,10 +19,15 @@ const MembersListContainer = styled.div`
   
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
   
     margin-bottom: 100px;
+
+    @media all and (min-width: 1280px) {
+        align-items: flex-start;
+        justify-content: flex-start;
+    }
+    align-items: center;
+    justify-content: center;
 `;
 
 export default MembersList;

--- a/pages/Members/MembersListItem.tsx
+++ b/pages/Members/MembersListItem.tsx
@@ -56,7 +56,7 @@ const MembersListItem = (props: Props) => {
 };
 
 const MemberItemImage = (props: { data: string }) => {
-    return <Image alt={"Profile Image"} src={props.data} width="150" height="150"/>
+    return <MemberImage alt={"Profile Image"} src={props.data} width="150" height="150"/>
 };
 
 const MemberItemDataSnsBtn = (props: { data: snsDataProps, type: string }) => {
@@ -95,7 +95,12 @@ const MemberItemDataSnsBtnIcon = (props: { type: string }) => {
     }
 };
 
-const MemberItemContainer = styled.div`
+const MemberItemContainer = styled.div` 
+    @media all and (max-width:479px) {
+        height: 120px;
+        width: 320px;
+    }
+
     height: 150px;
     width: 400px;
   
@@ -112,12 +117,28 @@ const MemberItemContainer = styled.div`
     }
 `;
 
+const MemberImage = styled(Image)`
+    @media all and (max-width:479px) {
+        height: 120px;
+        width: 120px;
+    }
+    height: 150px;
+    width: 150px;
+`;
+
 const MemberItemImageContainer = styled.div`
+    @media all and (max-width:479px) {
+        height: 120px;
+        width: 120px;
+    }
     height: 150px;
     width: 150px;
 `;
 
 const MemberItemDataContainer = styled.div`
+    @media all and (max-width:479px) {
+        height: 120px;
+    }
     height: 150px;
     width: 100%;
   
@@ -145,6 +166,10 @@ const MemberItemDataSnsContainer = styled.div`
 `;
 
 const MemberItemDataSnsBtnContainer = styled.div`
+    @media all and (max-width:479px) {
+        height: 25px;
+        width: 25px;
+    }
     height: 30px;
     width: 30px;
   
@@ -155,6 +180,9 @@ const MemberItemDataSnsBtnContainer = styled.div`
 `;
 
 const MemberItemDataComment = styled.p`
+    @media all and (max-width:479px) {
+        font-size: 12px;
+    }
     font-size: 14px;
     font-weight: 300;
     line-height: 23px;
@@ -163,12 +191,18 @@ const MemberItemDataComment = styled.p`
 `;
 
 const MemberItemDataCompany = styled.p`
+    @media all and (max-width:479px) {
+        font-size: 12px;
+    }
     font-size: 14px;
     font-weight: 700;
     line-height: 23px;
 `;
 
 const MemberItemDataID = styled.p`
+    @media all and (max-width:479px) {
+        font-size: 20px;
+    }
     font-size: 24px;
     font-weight: 800;
     line-height: 32px;
@@ -182,6 +216,9 @@ const MemberItemDataDivider = styled.p`
 `;
 
 const MemberItemDataName = styled.p`
+    @media all and (max-width:479px) {
+        font-size: 18px;    
+    }
     font-size: 20px;
     font-weight: 300;
     line-height: 34px;

--- a/pages/Members/MembersTitle.tsx
+++ b/pages/Members/MembersTitle.tsx
@@ -10,29 +10,77 @@ const MembersTitle = () => {
 };
 
 const MembersTitleContainer = styled.div`
-      width: 100%;
+    width: 100%;
       
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      justify-content: flex-start;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
 `;
 
 const MembersTitleMain = styled.p`
-    font-size: 55pt;
+    @media all and (min-width: 1280px) {
+        font-size: 55pt;
+        letter-spacing: -5px;
+    }
+    
+    /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
+    @media all and (min-width:1024px) and (max-width:1279px) {
+        font-size: 50pt;
+        letter-spacing: -4px;
+    }   
+    
+    /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
+    @media all and (min-width:768px) and (max-width:1023px) {
+        font-size: 45pt;
+        letter-spacing: -3px;
+    } 
+    
+    /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+    @media all and (min-width:480px) and (max-width:767px) {
+        font-size: 40pt;
+        letter-spacing: -2px;
+    } 
+    
+    /* 모바일 세로 (해상도 ~ 479px)*/ 
+    @media all and (max-width:479px) {
+        font-size: 35pt;
+        letter-spacing: -1px;
+    }
     font-weight: 900;
     line-height: 60px;
-    letter-spacing: -5px;
 
-    margin-bottom: -20px;
+    margin: 0 10px -20px 10px;
 `;
 
 const MembersTitleSub = styled.p`
-    font-size: 20pt;
+    @media all and (min-width: 1280px) {
+        font-size: 20pt;
+    }
+    
+    /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
+    @media all and (min-width:1024px) and (max-width:1279px) {
+        font-size: 18pt;
+    }   
+    
+    /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
+    @media all and (min-width:768px) and (max-width:1023px) {
+        font-size: 16pt;
+    } 
+    
+    /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+    @media all and (min-width:480px) and (max-width:767px) {
+        font-size: 14pt;
+    } 
+    
+    /* 모바일 세로 (해상도 ~ 479px)*/ 
+    @media all and (max-width:479px) {
+        font-size: 12pt;
+    }
     font-weight: 300;
     line-height: 35px;
 
-    margin-bottom: 100px;
+    margin: 0 10px 100px 10px;
 `;
 
 

--- a/pages/Projects/ProjectListItem.tsx
+++ b/pages/Projects/ProjectListItem.tsx
@@ -20,14 +20,35 @@ const ProjectListItem = (props: Props) => {
 
 const ListItemWrapper = styled.div`
   text-align: center;
-  margin 0 40px 0 40px;
+  @media all and (min-width: 768px) {
+    margin 0 20px 0 20px;
+  }
+  margin 0 10px 0 10px;
 `;
 
 const ListItemImage = styled.img`
-  width: 560px;
-  height: 324px;
-  border-radius: 20px;
-  object-fit: cover;
+  @media all and (min-width: 768px) {
+    width: 560px;
+    height: 324px;
+    border-radius: 20px;
+    object-fit: cover;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+  @media all and (min-width:480px) and (max-width:767px) {
+    width: 420px;
+    height: 243px;
+    border-radius: 20px;
+    object-fit: cover;
+  } 
+
+  /* 모바일 세로 (해상도 ~ 479px)*/ 
+  @media all and (max-width:479px) {
+    width: 280px;
+    height: 162px;
+    border-radius: 20px;
+    object-fit: cover;
+  }
 `;
 
 const ListItemTitle = styled.h2`

--- a/pages/Projects/ProjectSection.tsx
+++ b/pages/Projects/ProjectSection.tsx
@@ -25,19 +25,93 @@ const SectionWrapper = styled.div`
   justify-content: center;
   align-items: center;
 
-  & > div {
-    width: 1400px;
-  }
+  @media all and (min-width: 1280px) {
+    & > div {
+      width: 1400px;
+    }
+    
+    h1 {
+      text-align: left;
+      font-size: 55pt;
+    }
   
-  h1 {
-    text-align: left;
-    font-size: 55pt;
+    p {
+      margin: 1.5rem 0 1.5rem 0;
+      font-size: 18pt;
+      font-weight: 300;
+    }
   }
 
-  p {
-    margin: 1.5rem 0 1.5rem 0;
-    font-size: 18pt;
-    font-weight: 300;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
+  @media all and (min-width:1024px) and (max-width:1279px) {
+    & > div {
+      width: 1024px;
+    }
+    
+    h1 {
+      text-align: left;
+      font-size: 50pt;
+    }
+  
+    p {
+      margin: 1.5rem 0 1.5rem 0;
+      font-size: 16pt;
+      font-weight: 300;
+    }
+  }   
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
+  @media all and (min-width:768px) and (max-width:1023px) {
+    & > div {
+      width: 768px;
+    }
+    
+    h1 {
+      text-align: left;
+      font-size: 45pt;
+    }
+  
+    p {
+      margin: 1.5rem 0 1.5rem 0;
+      font-size: 14pt;
+      font-weight: 300;
+    }
+  } 
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+  @media all and (min-width:480px) and (max-width:767px) {
+    & > div {
+      width: 480px;
+    }
+    
+    h1 {
+      text-align: left;
+      font-size: 40pt;
+    }
+  
+    p {
+      margin: 1.5rem 0 1.5rem 0;
+      font-size: 12pt;
+      font-weight: 300;
+    }
+  } 
+
+  /* 모바일 세로 (해상도 ~ 479px)*/ 
+  @media all and (max-width:479px) {
+    & > div {
+      width: 360px;
+    }
+    
+    h1 {
+      text-align: left;
+      font-size: 30pt;
+    }
+  
+    p {
+      margin: 1.5rem 0 1.5rem 0;
+      font-size: 10pt;
+      font-weight: 300;
+    }
   }
 `;
 

--- a/pages/Projects/ProjectSection.tsx
+++ b/pages/Projects/ProjectSection.tsx
@@ -32,11 +32,12 @@ const SectionWrapper = styled.div`
     
     h1 {
       text-align: left;
+      margin-left: 0.5rem;
       font-size: 55pt;
     }
   
     p {
-      margin: 1.5rem 0 1.5rem 0;
+      margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 18pt;
       font-weight: 300;
     }
@@ -50,11 +51,12 @@ const SectionWrapper = styled.div`
     
     h1 {
       text-align: left;
+      margin-left: 0.5rem;
       font-size: 50pt;
     }
   
     p {
-      margin: 1.5rem 0 1.5rem 0;
+      margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 16pt;
       font-weight: 300;
     }
@@ -68,11 +70,12 @@ const SectionWrapper = styled.div`
     
     h1 {
       text-align: left;
+      margin-left: 0.5rem;
       font-size: 45pt;
     }
   
     p {
-      margin: 1.5rem 0 1.5rem 0;
+      margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 14pt;
       font-weight: 300;
     }
@@ -86,11 +89,12 @@ const SectionWrapper = styled.div`
     
     h1 {
       text-align: left;
+      margin-left: 0.5rem;
       font-size: 40pt;
     }
   
     p {
-      margin: 1.5rem 0 1.5rem 0;
+      margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 12pt;
       font-weight: 300;
     }
@@ -104,11 +108,12 @@ const SectionWrapper = styled.div`
     
     h1 {
       text-align: left;
+      margin-left: 0.5rem;
       font-size: 30pt;
     }
   
     p {
-      margin: 1.5rem 0 1.5rem 0;
+      margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 10pt;
       font-weight: 300;
     }

--- a/pages/Projects/[ProjectDetail].tsx
+++ b/pages/Projects/[ProjectDetail].tsx
@@ -32,7 +32,7 @@ const ProjectDetail = ()=> {
           <p>{projectData.description}</p>
         </ProjectDetailTitle>
         <ProjectDetailContent>
-          <ImageSlider width="600px" height="450px"
+          <ImageSlider
             images={projectData.image} />
           <br></br>
           
@@ -67,16 +67,81 @@ const ProjectDetailWrapper = styled.div`
 `;
 
 const ProjectDetailTitle = styled.div`
-  margin-top: 128px;
-  width: 1280px;
-  h1 {
-    text-align: left;
-    font-size: 55pt;
+  @media all and (min-width: 1280px) {
+    margin-top: 128px;
+    width: 1280px;
+    & > h1 {
+      text-align: left;
+      margin-left: 0.5rem;
+      font-size: 55pt;
+    }
+    & > p {
+      margin: 1.5rem 0 1.5rem 0.5rem;
+      font-size: 18pt;
+      font-weight: 300;
+    }
   }
-  p {
-    margin: 1.5rem 0 1.5rem 0;
-    font-size: 18pt;
-    font-weight: 300;
+
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
+  @media all and (min-width:1024px) and (max-width:1279px) {
+    margin-top: 128px;
+    width: 1024px;
+    & > h1 {
+      text-align: left;
+      margin-left: 0.5rem;
+      font-size: 50pt;
+    }
+    & > p {
+      margin: 1.5rem 0 1.5rem 0.5rem;
+      font-size: 16pt;
+      font-weight: 300;
+    }
+  }   
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
+  @media all and (min-width:768px) and (max-width:1023px) {
+    margin-top: 128px;
+    width: 768px;
+    & > h1 {
+      text-align: left;
+      margin-left: 0.5rem;
+      font-size: 45pt;
+    }
+    & > p {
+      margin: 1.5rem 0 1.5rem 0.5rem;
+      font-size: 14pt;
+      font-weight: 300;
+    }
+  } 
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+  @media all and (min-width:480px) and (max-width:767px) {
+    margin-top: 128px;
+    width: 480px;
+    & > h1 {
+      margin-left: 0.5rem;
+      font-size: 40pt;
+    }
+    & > p {
+      margin: 1.5rem 0 1.5rem 0.5rem;
+      font-size: 12pt;
+      font-weight: 300;
+    }
+  } 
+
+  /* 모바일 세로 (해상도 ~ 479px)*/ 
+  @media all and (max-width:479px) {
+    margin-top: 128px;
+    width: 360px;
+    & > h1 {
+      margin-left: 0.5rem;
+      font-size: 35pt;
+    }
+    & > p {
+      margin: 1.5rem 0 1.5rem 0.5rem;
+      font-size: 12pt;
+      font-weight: 300;
+    }
   }
 `;
 

--- a/pages/Projects/[ProjectDetail].tsx
+++ b/pages/Projects/[ProjectDetail].tsx
@@ -67,8 +67,8 @@ const ProjectDetailWrapper = styled.div`
 `;
 
 const ProjectDetailTitle = styled.div`
+  margin-top: 128px;
   @media all and (min-width: 1280px) {
-    margin-top: 128px;
     width: 1280px;
     & > h1 {
       text-align: left;
@@ -84,7 +84,6 @@ const ProjectDetailTitle = styled.div`
 
   /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
   @media all and (min-width:1024px) and (max-width:1279px) {
-    margin-top: 128px;
     width: 1024px;
     & > h1 {
       text-align: left;
@@ -100,14 +99,14 @@ const ProjectDetailTitle = styled.div`
 
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
   @media all and (min-width:768px) and (max-width:1023px) {
-    margin-top: 128px;
     width: 768px;
     & > h1 {
-      text-align: left;
+      text-align: center;
       margin-left: 0.5rem;
       font-size: 45pt;
     }
     & > p {
+      text-align: center;
       margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 14pt;
       font-weight: 300;
@@ -116,13 +115,14 @@ const ProjectDetailTitle = styled.div`
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
   @media all and (min-width:480px) and (max-width:767px) {
-    margin-top: 128px;
     width: 480px;
     & > h1 {
+      text-alitn: center;
       margin-left: 0.5rem;
       font-size: 40pt;
     }
     & > p {
+      text-align: center;
       margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 12pt;
       font-weight: 300;
@@ -131,13 +131,14 @@ const ProjectDetailTitle = styled.div`
 
   /* 모바일 세로 (해상도 ~ 479px)*/ 
   @media all and (max-width:479px) {
-    margin-top: 128px;
     width: 360px;
     & > h1 {
+      text-alitn: center;
       margin-left: 0.5rem;
       font-size: 35pt;
     }
     & > p {
+      text-align: center;
       margin: 1.5rem 0 1.5rem 0.5rem;
       font-size: 12pt;
       font-weight: 300;

--- a/src/Common/ImageSlider.tsx
+++ b/src/Common/ImageSlider.tsx
@@ -4,12 +4,7 @@ import styled from "styled-components";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
-interface Size {
-  width: string;
-  height: string;
-}
-
-interface Props extends Size {
+interface Props {
   images: Array<string>;
 }
 
@@ -23,7 +18,7 @@ const ImageSlider = (props: Props) => {
     slidesToScroll: 1,
   }
   return (
-    <SliderStyle width={props.width} height={props.height}>
+    <SliderStyle>
       <Slider {...settings} >
         {props.images.map((url, i) => (
           <img src={url} key={i}/>
@@ -33,16 +28,42 @@ const ImageSlider = (props: Props) => {
   );
 }
 
-const SliderStyle = styled.div<Size>`
+const SliderStyle = styled.div`
   ${props => {
     return `
-      width: ${props.width};
-      height: ${props.height};
-      margin-bottom: 64px;
-      img {
-        width: ${props.width};
-        height: ${props.height};
-        object-fit: contain;
+      @media all and (min-width:768px) {
+        width: 600px;
+        height: 450px;
+        margin-bottom: 64px;
+        img {
+          width: 600px;
+          height: 450px;
+          object-fit: contain;
+        }
+      }
+    
+      /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+      @media all and (min-width:480px) and (max-width:767px) {
+        width: 440px;
+        height: 330px;
+        margin-bottom: 64px;
+        img {
+          width: 440px;
+          height: 330px;
+          object-fit: contain;
+        }
+      } 
+    
+      /* 모바일 세로 (해상도 ~ 479px)*/ 
+      @media all and (max-width:479px) {
+        width: 360px;
+        height: 270px;
+        margin-bottom: 64px;
+        img {
+          width: 360px;
+          height: 270px;
+          object-fit: contain;
+        }
       }
     `;
   }}


### PR DESCRIPTION
# Summary
프로젝트 페이지와 멤버 페이지에 모바일 UI를 적용했습니다.
# Description
- 프로젝트 목록 페이지에 모바일 화면 대응
- 프로젝트 상세 페이지에 모바일 화면 대응
- 멤버 페이지에 모바일 화면 대응
- 멤버 아이템 클릭시 멤버 상세 정보 부분으로 화면 자동 스크롤
# ScreenShots
<img width="365" alt="스크린샷 2023-02-05 오후 4 33 41" src="https://user-images.githubusercontent.com/10252712/216807227-717b5f70-db58-4335-b0b3-c0bd39a9fbc2.png">
(너비 1024px 미만일 경우 제목, 부제목이 가운데로 정렬됩니다.)
<img width="365" alt="스크린샷 2023-02-07 오후 2 14 15" src="https://user-images.githubusercontent.com/10252712/217154465-eb37988c-f140-40f2-a7bc-216bd63fbef0.png">
<img width="366" alt="스크린샷 2023-02-07 오후 2 17 07" src="https://user-images.githubusercontent.com/10252712/217154836-b0da3fa4-fc50-4356-9549-26d2dec44636.png">
(멤버 클릭시 화면 스크롤이 상세 정보 부분까지 내려갑니다.)
<img width="366" alt="스크린샷 2023-02-07 오후 2 18 17" src="https://user-images.githubusercontent.com/10252712/217155218-36d77b50-f5d1-4a80-82e6-ee3b2395234d.png">
