### PR TITLE
[FIX] 멤버 페이지 관련 빌드 오류 해결

### DIFF
--- a/pages/Members/MembersDetail.tsx
+++ b/pages/Members/MembersDetail.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import React, { RefObject } from "react";
+import React from "react";
 import styled from "styled-components";
 
 import { MemberData } from "./Members";
@@ -117,4 +117,5 @@ const MembersDetailTitle = styled.p`
     margin: 0 0 15px 0;
 `;
 
+MembersDetail.displayName = "MembersDetail";
 export default MembersDetail;

--- a/pages/Projects/ProjectListItem.tsx
+++ b/pages/Projects/ProjectListItem.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import styled from "styled-components";
 
@@ -11,7 +12,7 @@ const ProjectListItem = (props: Props) => {
   return (
     <ListItemWrapper>
       <Link href={`Projects/${props.id}`}>
-        <ListItemImage src={props.image} />
+        <ListItemImage alt="Project Image" src={props.image} width={560} height={324} />
         <ListItemTitle>{props.title}</ListItemTitle>
       </Link>
     </ListItemWrapper>
@@ -26,29 +27,25 @@ const ListItemWrapper = styled.div`
   margin 0 10px 0 10px;
 `;
 
-const ListItemImage = styled.img`
+const ListItemImage = styled(Image)`
   @media all and (min-width: 768px) {
     width: 560px;
     height: 324px;
-    border-radius: 20px;
-    object-fit: cover;
   }
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
   @media all and (min-width:480px) and (max-width:767px) {
     width: 420px;
     height: 243px;
-    border-radius: 20px;
-    object-fit: cover;
   } 
 
   /* 모바일 세로 (해상도 ~ 479px)*/ 
   @media all and (max-width:479px) {
     width: 280px;
     height: 162px;
-    border-radius: 20px;
-    object-fit: cover;
   }
+  border-radius: 20px;
+  object-fit: cover;
 `;
 
 const ListItemTitle = styled.h2`

--- a/pages/Projects/ProjectListItem.tsx
+++ b/pages/Projects/ProjectListItem.tsx
@@ -12,7 +12,7 @@ const ProjectListItem = (props: Props) => {
   return (
     <ListItemWrapper>
       <Link href={`Projects/${props.id}`}>
-        <ListItemImage alt="Project Image" src={props.image} width={560} height={324} />
+        <ListItemImage alt="Project Image" src={`/${props.image}`} width={560} height={324} />
         <ListItemTitle>{props.title}</ListItemTitle>
       </Link>
     </ListItemWrapper>

--- a/src/Common/ImageSlider.tsx
+++ b/src/Common/ImageSlider.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import Image from "next/image";
 
 interface Props {
   images: Array<string>;
@@ -21,7 +22,7 @@ const ImageSlider = (props: Props) => {
     <SliderStyle>
       <Slider {...settings} >
         {props.images.map((url, i) => (
-          <img src={url} key={i}/>
+          <Image alt="Project Image" src={`/${url}`} key={i} width={600} height={450}/>
         ))}
       </Slider>
     </SliderStyle>


### PR DESCRIPTION
# Summary
멤버 페이지 관련 빌드 오류를 해결하고 프로젝트 페이지에서 전반적으로 사용한 img 태그를 next/imge로 변경했습니다.
# Description
- forwardRef 사용시 displayName 설정 -> 빌드 오류 원인
- ProjectListItem 컴포넌트에서 img 대신 next/image 사용
- ImageSlider 컴포넌트에서 img 대신 next/image 사용