### PR TITLE
[UPDATE] Main Mobile UI Layout

### DIFF
--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -90,6 +90,7 @@ const MainHistoryWrapper = styled.div<Props>`
   align-items: center;
   height: 100vh;
   font-family: "Noto Sans KR";
+  margin-bottom: 200px;
 `;
 
 const HistoryTitle = styled.div<Props>`

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -16,7 +16,7 @@ const MainTitle = () => {
   return (
     <MainTitleStyle>
       <TitleContentsStyle isDesktop={isDesktop}>
-      <Crab width={isDesktop ? 18 : 10} height={isDesktop ? 18 : 10} marginTop={2} />
+      <Crab width={isDesktop ? 18 : 12} height={isDesktop ? 18 : 12} marginTop={2} />
       <IntroStyle isDesktop={isDesktop}>
         <p>&quot;이거 님이 만드신 거였군요!&quot;</p>
         <h1>TEAM DEF:CON</h1>
@@ -54,17 +54,18 @@ const TitleContentsStyle = styled.div<Props>`
     margin-top: 15rem;
 
     h1 {
-      font-size: ${props=>props.isDesktop ? "100px" : "50px"};
+      font-size: ${props=>props.isDesktop ? "100px" : "70px"};
       font-weight: bolder;
       letter-spacing: -5px;
     }
     p {
-      font-size: ${props=>props.isDesktop ? "30px" : "15px"};
+      font-size: ${props=>props.isDesktop ? "30pt" : "18pt"};
       font-weight: bold;
+      letter-spacing: -1px;
     }
 
     #intro {
-      font-size: ${props=>props.isDesktop ? "25px" : "15px"};
+      font-size: ${props=>props.isDesktop ? "25pt" : "15pt"};
       font-weight: 300;
     }
 `;

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -43,6 +43,7 @@ const MainTitleStyle = styled.div`
   justify-content: center;
   align-items: center;
   font-family: "Noto Sans KR";
+  height: 100vh;
 `;
 
 const TitleContentsStyle = styled.div<Props>`

--- a/pages/Main/MainWorks.tsx
+++ b/pages/Main/MainWorks.tsx
@@ -2,6 +2,11 @@ import styled from "styled-components";
 import { ScrollMenu } from "react-horizontal-scrolling-menu";
 import WorksCard from "../../src/Common/WorksCard";
 import BackgroundCard from "../../src/Common/BackgroundCard";
+import { useMediaQuery } from "react-responsive";
+
+interface Props{
+  isDesktop: boolean;
+};
 
 const dummyArray = [
   {
@@ -33,15 +38,19 @@ const dummyArray = [
 
 
 const MainWorks = () => {
+  const isDesktop = useMediaQuery({
+    query: "(min-width:768px)",
+  });
+
   return (
     <MainWorksWrapper>
-      <MainWorksContents>
-      <WorksTitle>
+      <MainWorksContents isDesktop={isDesktop}>
+      <WorksTitle isDesktop={isDesktop}>
         <h1>우리가 즐겨온 일들</h1>
         <p>
-          우리 DEF:CON이 관심을 갖고 즐겨온 일들의 카테고리입니다.<br />
-          소프트웨어가 사용될 수 있다면 우리는 뭐든 재미있게 갖고 놀 수
-          있습니다.<br />
+          우리 DEF:CON이 관심을 갖고 즐겨온 일들의 카테고리입니다.<br/>
+          소프트웨어가 사용될 수 있다면 우리는 뭐든 재미있게 갖고 놀 수<br/>
+          있습니다.
         </p>
       </WorksTitle>
       <BackgroundCard
@@ -58,7 +67,7 @@ const MainWorks = () => {
         translateY={"35vh"}
         type={"bordered"}
       />
-			<ScrollMenuWrapper>
+			<ScrollMenuWrapper isDesktop={isDesktop}>
         <ScrollMenu>
           {dummyArray.map((items) => (
             <WorksCard key={items.id} text={items.text} image={items.image} />
@@ -79,32 +88,35 @@ const MainWorksWrapper = styled.div`
   margin-bottom: 200px;
 `;
 
-const MainWorksContents = styled.div`
+const MainWorksContents = styled.div<Props>`
   display: flex;
   flex-direction: column;
-  margin-left: 30rem;
+  align-items: ${props=>props.isDesktop ? "" : "center"};
+  margin-left: ${props=>props.isDesktop ? "400px" : "0px"};
 `;
 
-const WorksTitle = styled.div`
+const WorksTitle = styled.div<Props>`
   display: flex;
   flex-direction: column;
+  align-items:${props=>props.isDesktop ? "" : "center"};
   
 
 	h1 {
-    text-align: left;
-    font-size: 55pt;
-    letter-spacing: -7px;
+    text-align: ${props=>props.isDesktop ? "left" : "center"};
+    font-size: ${props=>props.isDesktop ? "55pt" : "40pt"};
+    letter-spacing: ${props=>props.isDesktop ? "-7px" : "-5px"};
   }
 
   p {
     margin-top: 10px;
-    font-size: 18pt;
+    font-size: ${props=>props.isDesktop ? "18pt" : "15pt"};
+    text-align: ${props=>props.isDesktop ? "18pt" : "center"};
     font-weight: 300;
   }
 `;
 
-const ScrollMenuWrapper = styled.div`
-  width: 65%;
+const ScrollMenuWrapper = styled.div<Props>`
+  width: ${props => props.isDesktop ? "70%" : "100%"};
   margin-top: 5vh;
 `;
 


### PR DESCRIPTION
# Description
- Main 페이지 내 Title, History, Awards, Works 네 개의 섹션에 대한 모바일 UI 구현
- 768px 기준으로 적용
- react-responsive 라이브러리의 useMediaQuery Hook을 활용하여 구현

# Image
![MainMobile](https://user-images.githubusercontent.com/47844901/217317508-76312757-9571-441d-a555-1797f29ababb.png)
