### PR TITLE
[FIX] Main Mobile UI : useMediaQuery Hook 사용 최소화

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -12,10 +12,6 @@ type MainEventData = {
   image: string;
 };
 
-interface Props {
-  isDesktop: boolean;
-}
-
 const tmpEventData: MainEventData = {
   title: "집에 가고 싶지 않으십니까?",
   content:
@@ -25,7 +21,7 @@ const tmpEventData: MainEventData = {
 
 const MainAwards = () => {
   const isDesktop = useMediaQuery({
-    query: "(min-width:768px)",
+    query: "(min-width:1208px)",
   });
   const [mainEvent, setMainEvent] = useState(tmpEventData);
 
@@ -36,7 +32,7 @@ const MainAwards = () => {
   }, []);
 
   return (
-    <MainAwardsStyle isDesktop={isDesktop}>
+    <MainAwardsStyle>
       {isDesktop ? (
         <>
           <AwardsContents>
@@ -59,16 +55,16 @@ const MainAwards = () => {
               </Link>
             </AwardsButton>
           </AwardsContents>
-          <AwardsTitle isDesktop={isDesktop}>
+          <AwardsTitle>
             <h1>{mainEvent.title}</h1>
-            <AwardsImage src={mainEvent.image} isDesktop={isDesktop}></AwardsImage>
+            <AwardsImage src={mainEvent.image}></AwardsImage>
           </AwardsTitle>
         </>
       ) : (
         <>
-          <AwardsTitle isDesktop={isDesktop}>
+          <AwardsTitle>
             <h1>{mainEvent.title}</h1>
-            <AwardsImage src={mainEvent.image} isDesktop={isDesktop}></AwardsImage>
+            <AwardsImage src={mainEvent.image}></AwardsImage>
           </AwardsTitle>
           <AwardsContents>
             <p>{mainEvent.content}</p>
@@ -118,32 +114,72 @@ const MainAwards = () => {
     </MainAwardsStyle>
   );
 };
+const MainAwardsContainer = styled.div`
+  @media all and (min-width: 1280px) {
+    width: 1400px;
+  }
 
-const MainAwardsStyle = styled.div<Props>`
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 1024px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 768px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 480px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 360px;
+  }
+`;
+
+const MainAwardsStyle = styled.div`
   display: flex;
-  flex-direction: ${(props) => (props.isDesktop ? "row" : "column")};
+  @media all and (min-width: 1280px) {
+    flex-direction: row;
+  }
+  flex-direction: column;
   justify-content: center;
   height: 100vh;
   font-family: "Noto Sans KR";
   margin-bottom: 200px;
 `;
 
-const AwardsTitle = styled.div<Props>`
+const AwardsTitle = styled.div`
   display: flex;
   flex-direction: column;
-  margin-left: ${props => props.isDesktop ? "10vw" : "0"};
+  @media all and (min-width: 1280px) {
+    margin-left: 10vw;
+  }
 
   h1 {
-    text-align: ${(props) => (props.isDesktop ? "right" : "center")};
-    font-size: ${(props) => (props.isDesktop ? "55pt" : "40pt")};
-    letter-spacing: ${(props) => (props.isDesktop ? "-7px" : "-5px")};
-    color: ${(props) => (props.isDesktop ? "#fff" : "#000")};
+    @media all and (min-width: 1280px) {
+      text-align: right;
+      font-size: 55pt;
+      letter-spacing: -7px;
+      color: #fff;
+    }
+    text-align: center;
+    font-size: 40pt;
+    letter-spacing: -5px;
+    color: #000;
   }
 `;
 
-const AwardsImage = styled.img<Props>`
-  width: ${props => props.isDesktop ? "600px" : "400px"};
-  height: ${props => props.isDesktop ? "400px" : "300px"};
+const AwardsImage = styled.img`
+  @media all and (min-width: 1280px) {
+    width: 600px;
+    height: 400px;
+  }
+  width: 400px;
+  height: 300px;
   margin-top: 20px;
   border-radius: 20px;
 `;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -2,27 +2,18 @@ import styled from "styled-components";
 import Link from "next/link";
 import Dbutton from "../../src/Common/Dbutton";
 import BackgroundCard from "../../src/Common/BackgroundCard";
-import { useMediaQuery } from "react-responsive";
-
-interface Props {
-  isDekstop: boolean;
-}
 
 const MainHistory = () => {
-  const isDesktop = useMediaQuery({
-    query: "(min-width:768px)",
-  });
-
   return (
-    <>
-      <MainHistoryWrapper isDekstop={isDesktop}>
-        <HistoryTitle isDekstop={isDesktop}>
+    <MainHistoryContainer>
+      <MainHistoryWrapper>
+        <HistoryTitle>
           <h1>
             시작은 성보고 꼭대기
             <br />
             컴퓨터실에서부터
           </h1>
-          <HistoryImage src={"/Images/testImage.png"} isDekstop={isDesktop}/>
+          <HistoryImage src={"/Images/testImage.png"} />
         </HistoryTitle>
         <BackgroundCard
           color={"#35B6F7"}
@@ -38,14 +29,14 @@ const MainHistory = () => {
           translateY={"11vh"}
           type={"filled"}
         />
-        <HistoryContents isDekstop={isDesktop}>
+        <HistoryContents>
           <p>
             DEF:CON은 성보고등학교 컴퓨터실에서 시작된 동아리로
             소프트웨어를 좋아하는 학생들이 모여 재미있는 일을 하던
             데에서 시작되었습니다. 학교 행사에도 적극적으로 참여해
             우리가 좋아하는 것들을 다른 학생들과 나눴죠.
           </p>
-          <HistoryButton isDekstop={isDesktop}>
+          <HistoryButton>
             <Link
               href="https://play.google.com/store/apps/details?id=com.defcon.sungbo&hl=ko&gl=US"
               target="_blank"
@@ -79,13 +70,42 @@ const MainHistory = () => {
           </HistoryButton>
         </HistoryContents>
       </MainHistoryWrapper>
-    </>
+    </MainHistoryContainer>
   );
 };
 
-const MainHistoryWrapper = styled.div<Props>`
+const MainHistoryContainer = styled.div`
+ @media all and (min-width: 1280px) {
+        width: 1400px;
+    }
+    
+    /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
+    @media all and (min-width:1024px) and (max-width:1279px) {
+        width: 1024px;
+    }   
+    
+    /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
+    @media all and (min-width:768px) and (max-width:1023px) {
+        width: 768px;
+    } 
+    
+    /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
+    @media all and (min-width:480px) and (max-width:767px) {
+        width: 480px;
+    } 
+    
+    /* 모바일 세로 (해상도 ~ 479px)*/ 
+    @media all and (max-width:479px) {
+        width: 360px;
+    }
+  
+`;
+const MainHistoryWrapper = styled.div`
   display: flex;
-  flex-direction: ${props => props.isDekstop ? "row" : "column"};
+  @media all and (min-width: 1280px) {
+    flex-direction: row;
+  }
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
@@ -93,38 +113,59 @@ const MainHistoryWrapper = styled.div<Props>`
   margin-bottom: 200px;
 `;
 
-const HistoryTitle = styled.div<Props>`
+const HistoryTitle = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: ${props => props.isDekstop ? "flex-start" : "center"};
+  @media all and (min-width: 1280px) {
+    align-items: flex-start;
+  }
+  align-items: center;
   h1 {
-    text-align: ${props => props.isDekstop ? "left" : "center"};
-    font-size: ${props => props.isDekstop ? "55pt" : "40pt"};
-    letter-spacing: ${props => props.isDekstop ? "-7px" : "-5px"};
+    @media all and (min-width: 1280px) {
+      text-align: left;
+      font-size:55pt;
+      letter-spacing: -7px;
+    }
+    text-align: center;
+    font-size: 40pt;
+    letter-spacing: -5px;
   }
 `;
 
-const HistoryImage = styled.img<Props>`
-  width: ${props => props.isDekstop ? "600px" : "400px"};
+const HistoryImage = styled.img`
+  @media all and (min-width: 1280px) {
+    width: 600px;
+  }
+  width: 400px;
   margin-top: 2vh;
   border-radius: 20px;
 `;
 
-const HistoryButton = styled.div<Props>`
+const HistoryButton = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: ${props => props.isDekstop ? "right" : "center"};
+  @media all and (min-width: 1280px) {
+    justify-content: right;
+  }
+  justify-content: center;
   margin: 0.5rem 0rem 0rem 0rem;
 `;
 
-const HistoryContents = styled.div<Props>`
-  margin-top: ${props => props.isDekstop ? "200px" : "10px"};
-  margin-left: ${props => props.isDekstop ? "160px" : "0px"};
+const HistoryContents = styled.div`
+  @media all and (min-width: 1280px) {
+    margin: 200px 0px 0px 160px;
+  }
+  margin:10px 0px 0px 0px;
 
   p {
-    width: ${props => props.isDekstop ? "34vw" : "90vw"};
-    text-align: ${props => props.isDekstop ? "right" : "center"};
-    font-size: ${props => props.isDekstop ? "18pt" : "15pt"};
+    @media all and (min-width: 1280px) {
+      width: 34vw;
+      text-align: right;
+      font-size: 18pt;
+    } 
+    width: 90vw;
+    text-align: center;
+    font-size: 15pt;
     font-weight: 300;
   }
 `;

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -10,14 +10,14 @@ interface Props {
 
 const MainTitle = () => {
   const isDesktop = useMediaQuery({
-    query: "(min-width:768px)",
+    query: "(min-width:1208px)",
   });
 
   return (
     <MainTitleStyle>
-      <TitleContentsStyle isDesktop={isDesktop}>
+      <TitleContentsStyle>
       <Crab width={isDesktop ? 18 : 12} height={isDesktop ? 18 : 12} marginTop={2} />
-      <IntroStyle isDesktop={isDesktop}>
+      <IntroStyle>
         <p>&quot;이거 님이 만드신 거였군요!&quot;</p>
         <h1>TEAM DEF:CON</h1>
         <p id="intro">
@@ -46,35 +46,52 @@ const MainTitleStyle = styled.div`
   height: 100vh;
 `;
 
-const TitleContentsStyle = styled.div<Props>`
+const TitleContentsStyle = styled.div`
     display: flex;
-    flex-direction: ${props=>props.isDesktop ? "row" : "column"};
+    @media all and (min-width: 1280px) {
+      flex-direction: row;
+      text-align: right;
+    }
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    text-align: ${props=>props.isDesktop ? "right" : "center"};
+    text-align: center;
     margin-top: 15rem;
 
     h1 {
-      font-size: ${props=>props.isDesktop ? "100px" : "70px"};
+      @media all and (min-width: 1280px) {
+        font-size:100px;
+      }
+      font-size: 70px;
       font-weight: bolder;
       letter-spacing: -5px;
     }
     p {
-      font-size: ${props=>props.isDesktop ? "30pt" : "18pt"};
+      @media all and (min-width: 1280px) {
+        font-size:30px;
+      }
+      font-size: 18px;
       font-weight: bold;
       letter-spacing: -1px;
     }
 
     #intro {
-      font-size: ${props=>props.isDesktop ? "25pt" : "15pt"};
+      @media all and (min-width: 1280px) {
+        font-size:25px;
+      }
+      font-size: 15px;
       font-weight: 300;
     }
 `;
 
-const IntroStyle = styled.div<Props>`
+const IntroStyle = styled.div`
   letter-spacing: 0.1rem;
-  margin: ${props=>props.isDesktop ? "5px 0px 0px 100px" : "100px 0px 0px 0px"};
-  font-size: ${props=>props.isDesktop ? "25px" : "10px"};
+  @media all and (min-width: 1280px) {
+    margin:5px 0px 0px 100px;
+    font-size: 25px;
+  }
+  margin: 100px 0px 0px 0px;
+  font-size: 10px;
 `;
 
 const ScrollIconStyle = styled.div`

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -16,20 +16,24 @@ const MainTitle = () => {
   return (
     <MainTitleStyle>
       <TitleContentsStyle>
-      <Crab width={isDesktop ? 18 : 12} height={isDesktop ? 18 : 12} marginTop={2} />
-      <IntroStyle>
-        <p>&quot;이거 님이 만드신 거였군요!&quot;</p>
-        <h1>TEAM DEF:CON</h1>
-        <p id="intro">
-          당신의 일상 속 유용한 소프트웨어가
-          <br />
-          우리의 작품이었으면 좋겠습니다.
-          <br />
-          <br />
-          2023년 새로워진 대학생 프로그래밍팀 DEF:CON을 만나보세요.
-        </p>
-      </IntroStyle>
-    </TitleContentsStyle>
+        <Crab
+          width={isDesktop ? 18 : 12}
+          height={isDesktop ? 18 : 12}
+          marginTop={2}
+        />
+        <IntroStyle>
+          <p>&quot;이거 님이 만드신 거였군요!&quot;</p>
+          <h1>TEAM DEF:CON</h1>
+          <p id="intro">
+            당신의 일상 속 유용한 소프트웨어가
+            <br />
+            우리의 작품이었으면 좋겠습니다.
+            <br />
+            <br />
+            2023년 새로워진 대학생 프로그래밍팀 DEF:CON을 만나보세요.
+          </p>
+        </IntroStyle>
+      </TitleContentsStyle>
       <ScrollIconStyle>
         <FontAwesomeIcon icon={faAngleDoubleDown} color="#4C6170" size="3x" />
       </ScrollIconStyle>
@@ -47,47 +51,47 @@ const MainTitleStyle = styled.div`
 `;
 
 const TitleContentsStyle = styled.div`
-    display: flex;
+  display: flex;
+  @media all and (min-width: 1280px) {
+    flex-direction: row;
+    text-align: right;
+  }
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  margin-top: 15rem;
+
+  h1 {
     @media all and (min-width: 1280px) {
-      flex-direction: row;
-      text-align: right;
+      font-size: 100px;
     }
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    margin-top: 15rem;
+    font-size: 70px;
+    font-weight: bolder;
+    letter-spacing: -5px;
+  }
+  p {
+    @media all and (min-width: 1280px) {
+      font-size: 30px;
+    }
+    font-size: 18px;
+    font-weight: bold;
+    letter-spacing: -1px;
+  }
 
-    h1 {
-      @media all and (min-width: 1280px) {
-        font-size:100px;
-      }
-      font-size: 70px;
-      font-weight: bolder;
-      letter-spacing: -5px;
+  #intro {
+    @media all and (min-width: 1280px) {
+      font-size: 25px;
     }
-    p {
-      @media all and (min-width: 1280px) {
-        font-size:30px;
-      }
-      font-size: 18px;
-      font-weight: bold;
-      letter-spacing: -1px;
-    }
-
-    #intro {
-      @media all and (min-width: 1280px) {
-        font-size:25px;
-      }
-      font-size: 15px;
-      font-weight: 300;
-    }
+    font-size: 15px;
+    font-weight: 300;
+  }
 `;
 
 const IntroStyle = styled.div`
   letter-spacing: 0.1rem;
   @media all and (min-width: 1280px) {
-    margin:5px 0px 0px 100px;
+    margin: 5px 0px 0px 100px;
     font-size: 25px;
   }
   margin: 100px 0px 0px 0px;

--- a/pages/Main/MainWorks.tsx
+++ b/pages/Main/MainWorks.tsx
@@ -2,82 +2,106 @@ import styled from "styled-components";
 import { ScrollMenu } from "react-horizontal-scrolling-menu";
 import WorksCard from "../../src/Common/WorksCard";
 import BackgroundCard from "../../src/Common/BackgroundCard";
-import { useMediaQuery } from "react-responsive";
 
-interface Props{
-  isDesktop: boolean;
-};
-
-const dummyArray = [
+const testArray = [
   {
     id: "w1",
     text: "Android",
-		image: "testImage.png"
+    image: "testImage.png",
   },
   {
     id: "w2",
     text: "iOS",
-		image: "testImage.png"
+    image: "testImage.png",
   },
   {
     id: "w3",
     text: "Self-Repair",
-		image: "testImage.png"
+    image: "testImage.png",
   },
   {
     id: "w4",
     text: "Web",
-		image: "testImage.png"
+    image: "testImage.png",
   },
   {
     id: "w5",
     text: "Chat Bot",
-		image: "testImage.png"
+    image: "testImage.png",
   },
 ];
 
-
 const MainWorks = () => {
-  const isDesktop = useMediaQuery({
-    query: "(min-width:768px)",
-  });
-
   return (
-    <MainWorksWrapper>
-      <MainWorksContents isDesktop={isDesktop}>
-      <WorksTitle isDesktop={isDesktop}>
-        <h1>우리가 즐겨온 일들</h1>
-        <p>
-          우리 DEF:CON이 관심을 갖고 즐겨온 일들의 카테고리입니다.<br/>
-          소프트웨어가 사용될 수 있다면 우리는 뭐든 재미있게 갖고 놀 수<br/>
-          있습니다.
-        </p>
-      </WorksTitle>
-      <BackgroundCard
-        color={"#C7E7FF"}
-        height={"35vh"}
-        translateX={"-60vw"}
-        translateY={"8vh"}
-        type={"bordered"}
-      />
-      <BackgroundCard
-        color={"#35B6F7"}
-        height={"35vh"}
-        translateX={"50vw"}
-        translateY={"35vh"}
-        type={"bordered"}
-      />
-			<ScrollMenuWrapper isDesktop={isDesktop}>
-        <ScrollMenu>
-          {dummyArray.map((items) => (
-            <WorksCard key={items.id} text={items.text} image={items.image} />
-          ))}
-        </ScrollMenu>
-			</ScrollMenuWrapper>
-      </MainWorksContents>
-    </MainWorksWrapper>
+    <MainWorksContainer>
+      <MainWorksWrapper>
+        <MainWorksContents>
+          <WorksTitle>
+            <h1>우리가 즐겨온 일들</h1>
+            <p>
+              우리 DEF:CON이 관심을 갖고 즐겨온 일들의 카테고리입니다.
+              <br />
+              소프트웨어가 사용될 수 있다면 우리는 뭐든 재미있게 갖고 놀 수
+              <br />
+              있습니다.
+            </p>
+          </WorksTitle>
+          <BackgroundCard
+            color={"#C7E7FF"}
+            height={"35vh"}
+            translateX={"-60vw"}
+            translateY={"8vh"}
+            type={"bordered"}
+          />
+          <BackgroundCard
+            color={"#35B6F7"}
+            height={"35vh"}
+            translateX={"50vw"}
+            translateY={"35vh"}
+            type={"bordered"}
+          />
+          <ScrollMenuWrapper>
+            <ScrollMenu>
+              {testArray.map((items) => (
+                <WorksCard
+                  key={items.id}
+                  text={items.text}
+                  image={items.image}
+                />
+              ))}
+            </ScrollMenu>
+          </ScrollMenuWrapper>
+        </MainWorksContents>
+      </MainWorksWrapper>
+    </MainWorksContainer>
   );
 };
+
+const MainWorksContainer = styled.div`
+  @media all and (min-width: 1280px) {
+    width: 1400px;
+  }
+
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 1024px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 768px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 480px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 360px;
+  }
+`;
 
 const MainWorksWrapper = styled.div`
   display: flex;
@@ -88,37 +112,47 @@ const MainWorksWrapper = styled.div`
   margin-bottom: 200px;
 `;
 
-const MainWorksContents = styled.div<Props>`
+const MainWorksContents = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: ${props=>props.isDesktop ? "" : "center"};
-  margin-left: ${props=>props.isDesktop ? "400px" : "0px"};
+  @media all and (min-width: 1280px) {
+    margin-left: 400px;
+  }
 `;
 
-const WorksTitle = styled.div<Props>`
+const WorksTitle = styled.div`
   display: flex;
   flex-direction: column;
-  align-items:${props=>props.isDesktop ? "" : "center"};
-  
 
-	h1 {
-    text-align: ${props=>props.isDesktop ? "left" : "center"};
-    font-size: ${props=>props.isDesktop ? "55pt" : "40pt"};
-    letter-spacing: ${props=>props.isDesktop ? "-7px" : "-5px"};
+  h1 {
+    @media all and (min-width: 1208px) {
+      text-align: left;
+      font-size: 55pt;
+      letter-spacing: -7px;
+    }
+    text-align: center;
+    font-size: 40pt;
+    letter-spacing: -5px;
   }
 
   p {
     margin-top: 10px;
-    font-size: ${props=>props.isDesktop ? "18pt" : "15pt"};
-    text-align: ${props=>props.isDesktop ? "18pt" : "center"};
+    @media all and (min-width: 1208px) {
+      font-size: 18pt;
+      text-align: left;
+    }
+    font-size: 15pt;
+    text-align: center;
     font-weight: 300;
   }
 `;
 
-const ScrollMenuWrapper = styled.div<Props>`
-  width: ${props => props.isDesktop ? "70%" : "100%"};
+const ScrollMenuWrapper = styled.div`
+  @media all and (min-width: 1208px) {
+    width: 70%;
+  }
+  width: 100%;
   margin-top: 5vh;
 `;
-
 
 export default MainWorks;

--- a/pages/Members/Members.tsx
+++ b/pages/Members/Members.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 
 import * as API from "../../src/Common/API";
@@ -6,133 +6,136 @@ import MembersTitle from "./MembersTitle";
 import MembersList from "./MembersList";
 import MembersDetail from "./MembersDetail";
 
-interface Props{
-    marginBotton: boolean;
-};
+interface Props {
+  marginBotton: boolean;
+}
 
 const tmpMemberData: MemberData = {
-    id: "",
-    data: {
-        comment: "",
-        company: "",
-        company_img: "",
-        profileImage: "",
-        name: "",
-        history: [],
-        blog: {isEnabled: false, url: ""},
-        boj: {isEnabled: false, url: "", username: ""},
-        facebook: {isEnabled: false, url: ""},
-        github: {isEnabled: false, url: ""},
-        instagram: {isEnabled: false, url: ""},
-        twitter: {isEnabled: false, url: ""}
-    }
-}
+  id: "",
+  data: {
+    comment: "",
+    company: "",
+    company_img: "",
+    profileImage: "",
+    name: "",
+    history: [],
+    blog: { isEnabled: false, url: "" },
+    boj: { isEnabled: false, url: "", username: "" },
+    facebook: { isEnabled: false, url: "" },
+    github: { isEnabled: false, url: "" },
+    instagram: { isEnabled: false, url: "" },
+    twitter: { isEnabled: false, url: "" },
+  },
+};
 
 const tmpMemberList: Array<MemberData> = [tmpMemberData];
 
 const Members = () => {
-    const [isFirstClicked, setIsFirstClicked] = useState(false);
-    const [memberData, setMemberData] = useState(tmpMemberData);
-    const [memberList, setMemberList] = useState(tmpMemberList);
-    const membersDetailRef = useRef<HTMLDivElement>(null);
+  const [isFirstClicked, setIsFirstClicked] = useState(false);
+  const [memberData, setMemberData] = useState(tmpMemberData);
+  const [memberList, setMemberList] = useState(tmpMemberList);
+  const membersDetailRef = useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-        API.getMemberList().then((apiResult : any) => {
-            setMemberList(apiResult["data"]);
-        });
-    }, []);
+  useEffect(() => {
+    API.getMemberList().then((apiResult: any) => {
+      setMemberList(apiResult["data"]);
+    });
+  }, []);
 
-    const onMemberClick = (id: string) => {
-        setIsFirstClicked(true);
-        API.getMemberData(id).then((apiResult : any) => {
-            setMemberData({id: id, data: apiResult});
-            membersDetailRef.current?.scrollIntoView({behavior: "smooth"});
-        });
-    }
+  const onMemberClick = (id: string) => {
+    setIsFirstClicked(true);
+    API.getMemberData(id).then((apiResult: any) => {
+      setMemberData({ id: id, data: apiResult });
+      membersDetailRef.current?.scrollIntoView({ behavior: "smooth" });
+    });
+  };
 
-    return (
-        <MembersStyle marginBotton={isFirstClicked}>
-            <MembersContainer>
-                <MembersTitle />
-                <MembersViewContainer>
-                    <MembersList memberData={memberList} onClick={onMemberClick}/>
-                    <MembersDetail ref={membersDetailRef} isFirstClicked={isFirstClicked} memberData={memberData}/>
-                </MembersViewContainer>
-            </MembersContainer>
-        </MembersStyle>
-    );
+  return (
+    <MembersStyle marginBotton={isFirstClicked}>
+      <MembersContainer>
+        <MembersTitle />
+        <MembersViewContainer>
+          <MembersList memberData={memberList} onClick={onMemberClick} />
+          <MembersDetail
+            ref={membersDetailRef}
+            isFirstClicked={isFirstClicked}
+            memberData={memberData}
+          />
+        </MembersViewContainer>
+      </MembersContainer>
+    </MembersStyle>
+  );
 };
 
 const MembersStyle = styled.div<Props>`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  
-    font-family: "Noto Sans KR";
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 
-    margin-bottom: ${props => props.marginBotton && '50vh'};
+  font-family: "Noto Sans KR";
+
+  margin-bottom: ${(props) => props.marginBotton && "50vh"};
 `;
 
 const MembersContainer = styled.div`
-    height: 100%;
-    margin-top: 150px;
-    @media all and (min-width: 1280px) {
-        width: 1400px;
-    }
-    
-    /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
-    @media all and (min-width:1024px) and (max-width:1279px) {
-        width: 1024px;
-    }   
-    
-    /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
-    @media all and (min-width:768px) and (max-width:1023px) {
-        width: 768px;
-    } 
-    
-    /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
-    @media all and (min-width:480px) and (max-width:767px) {
-        width: 480px;
-    } 
-    
-    /* 모바일 세로 (해상도 ~ 479px)*/ 
-    @media all and (max-width:479px) {
-        width: 360px;
-    }
+  height: 100%;
+  margin-top: 150px;
+  @media all and (min-width: 1280px) {
+    width: 1400px;
+  }
+
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 1024px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 768px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 480px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 360px;
+  }
 `;
 
 const MembersViewContainer = styled.div`
-    height: 100%;
-    width: 100%;
-  
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+  height: 100%;
+  width: 100%;
 
-    @media all and (min-width: 1280px) {
-        flex-direction: row;
-    }
-    flex-direction: column;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+
+  @media all and (min-width: 1280px) {
+    flex-direction: row;
+  }
+  flex-direction: column;
 `;
 
 export type MemberData = {
-    id: string,
-    data: {
-        comment: string,
-        company: string,
-        company_img: string,
-        profileImage: string,
-        name: string,
-        history: Array<{content: string, date: string}>
-        blog: {isEnabled: boolean, url: string},
-        boj: {isEnabled: boolean, url: string, username: string},
-        facebook: {isEnabled: boolean, url: string},
-        github: {isEnabled: boolean, url: string},
-        instagram: {isEnabled: boolean, url: string},
-        twitter: {isEnabled: boolean, url: string}
-    }
-
+  id: string;
+  data: {
+    comment: string;
+    company: string;
+    company_img: string;
+    profileImage: string;
+    name: string;
+    history: Array<{ content: string; date: string }>;
+    blog: { isEnabled: boolean; url: string };
+    boj: { isEnabled: boolean; url: string; username: string };
+    facebook: { isEnabled: boolean; url: string };
+    github: { isEnabled: boolean; url: string };
+    instagram: { isEnabled: boolean; url: string };
+    twitter: { isEnabled: boolean; url: string };
+  };
 };
 
 export default Members;

--- a/src/Common/Footer.tsx
+++ b/src/Common/Footer.tsx
@@ -1,68 +1,123 @@
 import styled from "styled-components";
 import Link from "next/link";
-import { useMediaQuery } from "react-responsive";
-
-interface Props {
-  isDesktop: boolean;
-}
 
 const Footer = () => {
-  const isDesktop = useMediaQuery({
-    query: "(min-width:768px)",
-  });
-
   return (
-    <FooterDiv>
-      <FooterContents isDesktop={isDesktop}>
-        <Link href="/"><FooterLogo src="/Images/subLogo.svg" isDesktop={isDesktop} /></Link>
-        <FooterContexts isDesktop={isDesktop}>
-          <p>
-            <span><Link href="/Privacy">DEF:CON 개인정보보호정책</Link></span><br/>
-            (c)2023 DEF:CON ALL RIGHTS RESERVED<br/>
-            Designed By HarenKei From Seoul, Korea
-          </p>
-          <p>
-            이 페이지의 모든 소스코드는 <span><Link href="https://github.com/DefCon-Apps/DefCon-FE" target="_blank" rel="noreferrer">DEF:CON GitHub</Link></span>에서 확인하실 수 있습니다.
-          </p>
-        </FooterContexts>
-      </FooterContents>
-    </FooterDiv>
+    <FooterContainer>
+      <FooterDiv>
+        <FooterContents>
+          <Link href="/">
+            <FooterLogo src="/Images/subLogo.svg" />
+          </Link>
+          <FooterContexts>
+            <p>
+              <span>
+                <Link href="/Privacy">DEF:CON 개인정보보호정책</Link>
+              </span>
+              <br />
+              (c)2023 DEF:CON ALL RIGHTS RESERVED
+              <br />
+              Designed By HarenKei From Seoul, Korea
+            </p>
+            <p>
+              이 페이지의 모든 소스코드는{" "}
+              <span>
+                <Link
+                  href="https://github.com/DefCon-Apps/DefCon-FE"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  DEF:CON GitHub
+                </Link>
+              </span>
+              에서 확인하실 수 있습니다.
+            </p>
+          </FooterContexts>
+        </FooterContents>
+      </FooterDiv>
+    </FooterContainer>
   );
 };
+
+const FooterContainer = styled.div`
+  @media all and (min-width: 1280px) {
+    width: 1400px;
+  }
+
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 1024px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 768px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 480px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 360px;
+  }
+`;
 
 const FooterDiv = styled.div`
   width: 100vw;
   color: #fff;
   background-color: #001e2e;
-  font-family: 'Noto Sans KR';
+  font-family: "Noto Sans KR";
 `;
 
-const FooterContents = styled.div<Props>`
+const FooterContents = styled.div`
   display: flex;
   flex-direction: column;
-  padding:${props => props.isDesktop ? "2rem 10rem 2rem 10rem" : "2rem 2rem 2rem 2rem"};
-  p{
+  @media all and (min-width: 1024px) {
+    padding: 2rem 10rem 2rem 10rem;
+  }
+  padding: 2rem 2rem 2rem 2rem;
+
+  p {
+    @media all and (min-width: 1024px) {
+      font-size: 10pt;
+      margin-bottom: 0px;
+    }
+
     letter-spacing: 0.1rem;
     font-weight: lighter;
-    font-size: ${props => props.isDesktop ? "10pt" : "8pt"};
-    margin-bottom: ${props => props.isDesktop ? "0px" : "20px"};
+    font-size: 8pt;
+    margin-bottom: 20px;
   }
 
-  p span{
+  p span {
     font-weight: bold;
   }
 `;
 
-const FooterContexts = styled.div<Props>`
+const FooterContexts = styled.div`
   display: flex;
-  flex-direction: ${props => props.isDesktop ? "row" : "column"};
+
+  @media all and (min-width: 1024px) {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+
+  flex-direction: column;
   justify-content: space-between;
-  align-items: ${props => props.isDesktop ? "flex-end" : "flex-start"};
+  align-items: flex-start;
 `;
 
-const FooterLogo = styled.img<Props>`
-  width: ${props => props.isDesktop ? "240px" : "120px"};
-  height: ${props => props.isDesktop ? "160px" : "80px"};
+const FooterLogo = styled.img`
+  @media all and (min-width: 1024px) {
+    width: 240px;
+    height: 160px;
+  }
+
+  width: 120px;
+  height: 80px;
 `;
 
 export default Footer;

--- a/src/Common/Header.tsx
+++ b/src/Common/Header.tsx
@@ -1,27 +1,56 @@
 import Link from "next/link";
 import styled from "styled-components";
-import { useMediaQuery } from "react-responsive";
-
-interface Props{
-  isDesktop : boolean;
-}
 
 const Header = () => {
-  const isDesktop = useMediaQuery({
-    query: "(min-width:768px)",
-  });
-
   return (
-    <HeaderDiv>
-        <Link href="/"><HeaderLogo src="/Images/mainLogo.svg" isDesktop={isDesktop}/></Link>
-      <HeaderNavUl isDesktop={isDesktop}>
-        <HeaderNavLi isDesktop={isDesktop}><Link href="/Designs">Designs </Link></HeaderNavLi>
-        <HeaderNavLi isDesktop={isDesktop}><Link href="/Projects">Projects</Link></HeaderNavLi>
-        <HeaderNavLi isDesktop={isDesktop}><Link href="/Members">Members</Link></HeaderNavLi>
-      </HeaderNavUl>
-    </HeaderDiv>
+    <HeaderContainer>
+      <HeaderDiv>
+        <Link href="/">
+          <HeaderLogo src="/Images/mainLogo.svg" />
+        </Link>
+        <HeaderNavUl>
+          <HeaderNavLi>
+            <Link href="/Designs">Designs </Link>
+          </HeaderNavLi>
+          <HeaderNavLi>
+            <Link href="/Projects">Projects</Link>
+          </HeaderNavLi>
+          <HeaderNavLi>
+            <Link href="/Members">Members</Link>
+          </HeaderNavLi>
+        </HeaderNavUl>
+      </HeaderDiv>
+    </HeaderContainer>
   );
 };
+
+const HeaderContainer = styled.div`
+  height: 8vh;
+
+  @media all and (min-width: 1280px) {
+    width: 1400px;
+  }
+
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 1024px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 768px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 480px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 360px;
+  }
+`;
 
 const HeaderDiv = styled.div`
   display: flex;
@@ -30,34 +59,44 @@ const HeaderDiv = styled.div`
   width: 100vw;
   height: 8vh;
   position: fixed;
-  top : 0;
+  top: 0;
   z-index: 3;
-  font-family: 'Noto Sans KR';
+  font-family: "Noto Sans KR";
 `;
 
-const HeaderLogo = styled.img<Props>`
+const HeaderLogo = styled.img`
   width: 150px;
   height: 30px;
-  margin-left: ${props => props.isDesktop ? "1.5rem" : "0.5rem"};
+  @media all and (min-width: 1024px) {
+    margin-left: 1.5rem;
+  }
+  margin-left: 0.5rem;
   margin-top: 1.5rem;
 `;
 
-const HeaderNavUl = styled.ul<Props>`
+const HeaderNavUl = styled.ul`
   display: flex;
   flex-flow: row nowrap;
-  
+
   margin-top: 2.5rem;
-  margin-right: ${props => props.isDesktop ? "2rem" : "0.9rem"};
+  @media all and (min-width: 1024px) {
+    margin-right: 2rem;
+  }
+  margin-right: 0.9rem;
   font-size: 15pt;
   font-weight: bold;
 `;
 
-const HeaderNavLi = styled.li<Props>`
+const HeaderNavLi = styled.li`
   margin-left: 2rem;
-  padding-bottom: ${props => props.isDesktop ? "5px" : "15px"};
+  padding-bottom: 15px;
   list-style: none;
-  a{text-decoration:none;}
-  a:visited{color : #0e0e0e;}
+  a {
+    text-decoration: none;
+  }
+  a:visited {
+    color: #0e0e0e;
+  }
 `;
 
 export default Header;


### PR DESCRIPTION
# Description
- Member 페이지와 동일하게 1208px 기준의 미디어 쿼리를 styled-component에 적용하여 반응형을 구현하였습니다.
- 그에 따라 기존에 반응형 구현을 위해 사용한 react-responsive 라이브러리의 useMediaQuery Hook의 사용을 최대한 지양하여 코드를 수정하였습니다.
- 작동은 기존 768px을 기준으로 모바일/데스크탑을 구현했던 때보다 훨씬 자연스러워졌습니다.
- 싹 갈아엎느라 힘든 관계로 Design 페이지는 기상 후에 해드리겠습니다.
- 이상 전달 끝