### PR TITLE
[FIX] react-hydration 관련 오류 & 모바일 화면 여백 문제

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -20,16 +20,18 @@ const tmpEventData: MainEventData = {
 };
 
 const MainAwards = () => {
-  const isDesktop = useMediaQuery({
+  const desktop = useMediaQuery({
     query: "(min-width:1208px)",
   });
+  const [isDesktop, setDesktop] = useState(false);
   const [mainEvent, setMainEvent] = useState(tmpEventData);
 
   useEffect(() => {
+    if (desktop) setDesktop(true);
     API.getMainEventData().then((apiResult: any) => {
       setMainEvent(apiResult);
     });
-  }, []);
+  }, [desktop]);
 
   return (
     <MainAwardsStyle>

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -3,15 +3,21 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleDown } from "@fortawesome/free-solid-svg-icons";
 import { useMediaQuery } from "react-responsive";
+import { useEffect, useState } from "react";
 
 interface Props {
   isDesktop: boolean;
 }
 
 const MainTitle = () => {
-  const isDesktop = useMediaQuery({
+  const desktop = useMediaQuery({
     query: "(min-width:1208px)",
   });
+  const [isDesktop, setDesktop] = useState(false);
+
+  useEffect(() => {
+    if (desktop) setDesktop(true);
+  }, [desktop]);
 
   return (
     <MainTitleStyle>

--- a/src/Common/BackgroundCard.tsx
+++ b/src/Common/BackgroundCard.tsx
@@ -26,6 +26,9 @@ const BackgroundCard = (props: Props) => {
 };
 
 const CardStyled = styled.div<Props>`
+  @media all and (max-width: 1279px) {
+    display: none;
+  }
   position: absolute;
   left: 0;
   width: ${(props) => props.width};


### PR DESCRIPTION
# Summary
react-hydration 관련 오류 & 모바일 화면에서 오른쪽 여백이 생기는 문제 해결
# Description
- useMediaQuery를 사용하는 컴포넌트에 state를 하나씩 추가했습니다.
- **BackgroundCard**가 모바일 화면에서 문제를 일으키던 원인이었습니다.  
  - BackgroundCard의 `position:absoulte` 때문에 대참사가 일어났던 것 같습니다.
  - 너비가 1280px 미만일 경우 BackcgroundCard의 display를 none으로 설정했습니다.