### PR TITLE
[FIX] Main 페이지 레이아웃 오류 수정

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -132,6 +132,7 @@ const MainAwardsStyle = styled.div`
   display: flex;
   flex-direction: column;
   @media screen and (min-width: 1280px) {
+    justify-content: flex-end;
     align-items: flex-end;
   }
 
@@ -141,13 +142,15 @@ const MainAwardsStyle = styled.div`
 `;
 
 const AwardsTitle = styled.div`
+  @media screen and (min-width: 1280px) {
+    width: 50%;
+  }
   h1 {
     @media screen and (min-width: 1280px) {
-      width: 1400px;
       text-align: right;
       font-size: 55pt;
       letter-spacing: -7px;
-      color: #fff;
+      color: #000;
     }
 
     @media screen and (max-width: 768px) {

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -150,7 +150,7 @@ const AwardsTitle = styled.div`
       text-align: right;
       font-size: 55pt;
       letter-spacing: -7px;
-      color: #000;
+      color: #fff;
     }
 
     @media screen and (max-width: 768px) {

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -143,7 +143,7 @@ const MainAwardsStyle = styled.div`
 
 const AwardsTitle = styled.div`
   @media screen and (min-width: 1280px) {
-    width: 50%;
+    width: 60%;
   }
   h1 {
     @media screen and (min-width: 1280px) {
@@ -155,7 +155,7 @@ const AwardsTitle = styled.div`
 
     @media screen and (max-width: 768px) {
       text-align: center;
-      font-size: 40pt;
+      font-size: 35pt;
       letter-spacing: -5px;
       color: #000;
     }
@@ -204,13 +204,13 @@ const AwardsContents = styled.div`
   p {
     font-weight: 100;
     @media screen and (min-width: 1280px) {
-      width: 40vw;
+      width: 80%;
       text-align: left;
       font-size: 18pt;
     }
 
     @media screen and (max-width: 768px) {
-      width: 85vw;
+      width: 100%;
       margin-top: 5vh;
       margin-bottom: 5vh;
       text-align: center;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -100,6 +100,7 @@ const HistoryTitle = styled.div`
   align-items: center;
   h1 {
     @media screen and (min-width: 1280px) {
+      width: 100%;
       text-align: left;
       font-size: 55pt;
       letter-spacing: -7px;


### PR DESCRIPTION
# Descriptions
- 각 섹션 타이틀을 이루는 구역에 width를 % 단위로 지정하였습니다.
- macOS 해상도 옵션 중 "추가 공간" 에서도 이상 없이 작동하는 것을 확인하였습니다.
- 모바일에서는 기존 버전과 동일하게 작동합니다.

# Images
![FixError](https://user-images.githubusercontent.com/47844901/220632363-807d2a18-44f9-44e9-8588-b0166dc5dfd5.png)
MainAwards 섹션의 타이틀이 고장나보이는 것은 배경 사각형을 고려하여 텍스트 색상을 흰색으로 지정했기 때문입니다.
텍스트 색상을 검은색으로 통일하거나 배경의 사각형을 조정하면 해결될 문제입니다.