### PR TITLE
[FIX] Designs 페이지 레이아웃 오류 수정

### DIFF
--- a/pages/Designs/CrabIntro.tsx
+++ b/pages/Designs/CrabIntro.tsx
@@ -148,7 +148,7 @@ const CrabIntroDesc = styled.div`
     }
 
     @media screen and (max-width: 768px) {
-      width: 80vw;
+      width: 65vw;
       text-align: center;
     }
   }

--- a/pages/Designs/CrabIntro.tsx
+++ b/pages/Designs/CrabIntro.tsx
@@ -53,17 +53,12 @@ const CrabIntro = () => {
             <CrabIntroDesc>
               <p>
                 DEF:CON의 마스코트인 DEF:CON CRAB은 메인 컬러와 마찬가지로
-                <br />
-                Windows 10의 블루스크린에서 착안하였습니다.
-                <br />
-                DEF:CON의 철자 C의 앞에 콜론 (:)을 삽입하여 블루스크린의
-                이모티콘인 &quot;:(&quot;을 연상할 수 있게 만들어냈죠.
-                <br />
-                <br />
-                코딩을 하다보면 웃음을 지을 때보단 울상일 때가 더 많은 우리의{" "}
-                <br />
-                표정과도 비슷한 DEF:CON CRAB은 DEF:CON의 초창기 로고부터 <br />
-                유지되어온 DEF:CON의 헤리티지입니다. <br />
+                Windows 10의 블루스크린에서 착안하였습니다. DEF:CON의 철자 C의
+                앞에 콜론 (:)을 삽입하여 블루스크린의 이모티콘인
+                &quot;:(&quot;을 연상할 수 있게 만들어냈죠. 코딩을 하다보면
+                웃음을 지을 때보단 울상일 때가 더 많은 우리의 표정과도 비슷한
+                DEF:CON CRAB은 DEF:CON의 초창기 로고부터 유지되어온 DEF:CON의
+                헤리티지입니다.
               </p>
             </CrabIntroDesc>
           </>
@@ -96,74 +91,72 @@ const CrabIntro = () => {
 
 const CrabIntroWrapper = styled.div`
   height: 100vh;
-  @media screen and (min-width: 1280px) {
-    margin-bottom: 10vh;
-  }
-  margin-bottom: 20vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   font-family: "Noto Sans KR";
+
+  @media screen and (min-width: 1280px) {
+    margin-bottom: 10vh;
+  }
+  @media screen and (max-width: 768px) {
+    margin-bottom: 20vh;
+  }
 `;
 
 const CrabIntroContents = styled.div`
   display: flex;
+
   @media screen and (min-width: 1280px) {
     flex-direction: row;
-    justify-content: flex-start;
-    align-items: flex-start;
+    justify-content: space-evenly;
+    align-items: center;
   }
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
 `;
 
 const CrabIntroTitle = styled.h1`
   @media screen and (min-width: 1280px) {
+    width: 50%;
     font-size: 45pt;
     letter-spacing: -5px;
     text-align: right;
   }
 
-  @media screen and (min-width: 768px) {
+  @media screen and (max-width: 768px) {
     font-size: 40pt;
+    letter-spacing: -2px;
+    text-align: center;
   }
-
-  font-size: 30pt;
-  letter-spacing: -2px;
-  text-align: center;
 `;
 
 const CrabIntroDesc = styled.div`
-  @media screen and (min-width: 1280px) {
-    width: 50%;
-    margin-top: 0;
-    margin-right: 12vw;
-    font-size: 16pt;
-    font-weight: 100;
-    text-align: left;
-  }
-
-  @media screen and (min-width: 768px) {
-    width: 50%;
-    margin-top: 0;
-    margin-right: 12vw;
-    font-size: 16pt;
-    font-weight: 100;
-    text-align: center;
-  }
-
-  width: 85%;
   margin-top: 5vh;
-  margin-right: 0;
-  font-size: 12pt;
   font-weight: 100;
-  font-weight: 100;
+  font-size: 16pt;
+
+  p {
+    @media screen and (min-width: 1280px) {
+      width: 60vw;
+      text-align: left;
+    }
+
+    @media screen and (max-width: 768px) {
+      width: 80vw;
+      text-align: center;
+    }
+  }
 `;
 
 const CrabIntroLogoWrapper = styled.div`
   display: flex;
+
   @media screen and (min-width: 1280px) {
     flex-direction: row;
     margin-top: 8vh;
@@ -171,10 +164,12 @@ const CrabIntroLogoWrapper = styled.div`
     align-items: flex-start;
   }
 
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin-top: 5vh;
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    margin-top: 5vh;
+    justify-content: center;
+    align-items: center;
+  }
 `;
 
 const LogoHistoryWrapper = styled.div`
@@ -187,19 +182,25 @@ const LogoHistoryWrapper = styled.div`
     margin-top: 5vh;
     margin-right: 20vw;
   }
-  margin-top: 5vh;
-  margin-right: 0;
+
+  @media screen and (max-width: 768px) {
+    margin-top: 5vh;
+    margin-right: 0;
+  }
 `;
 
 const Logo = styled.img`
+  filter: drop-shadow(1px 1px 3px grey);
+
   @media screen and (min-width: 1280px) {
     width: 20vw;
     margin-bottom: 8vh;
   }
-  width: 50vw;
-  margin-bottom: 8vh;
 
-  filter: drop-shadow(1px 1px 3px grey);
+  @media screen and (max-width: 768px) {
+    width: 50vw;
+    margin-bottom: 8vh;
+  }
 `;
 
 export default CrabIntro;

--- a/pages/Designs/LogoIntro.tsx
+++ b/pages/Designs/LogoIntro.tsx
@@ -4,109 +4,118 @@ import BackgroundCard from "../../src/Common/BackgroundCard";
 const LogoIntro = () => {
   return (
     <LogoIntroWrapper>
-      <LogoIntroContents>
+      <LogoIntroContainer>
         <LogoIntroTitle>
-          아주 짧은 고민이 만든
-          <br />
-          의미 있는 DEF:CON의 얼굴
+          <h1>
+            아주 짧은 고민이 만든
+            <br />
+            의미 있는 DEF:CON의 얼굴
+          </h1>
         </LogoIntroTitle>
-        <LogoIntroImg src="/Images/mainLogo.svg" />
-      </LogoIntroContents>
-      <LogoIntroContext>
-        <p>
-          우리들의 로고는 30분 남짓의 아주 짧은 시간에 고안되었습니다.
-          <br />
-          고등학교 짧은 점심시간을 충분히 활용한 결과라고 할 수 있죠.
-          <br />
-          로고에 사용된 메인 색상은 Windows 10의 테마의 색상에서 영감을 얻었고
-          <br />
-          &quot;DEF:CON CRAB&quot;과 세미콜론(;)은 우리의 메인 테마 컬러를 입혀
-          <br />
-          단조로울 수 있는 텍스트 중심의 로고에 포인트 요소가 되었습니다.
-        </p>
-      </LogoIntroContext>
-      <BackgroundCard
-        color="#00658F"
-        height="22rem"
-        translateX="-1000px"
-        translateY="140px"
-        type="bordered"
-      />
+
+        <LogoIntroContents>
+          <LogoIntroImg src="/Images/mainLogo.svg" />
+          <p>
+            우리들의 로고는 30분 남짓의 아주 짧은 시간에 고안되었습니다.
+            고등학교 짧은 점심시간을 충분히 활용한 결과라고 할 수 있죠. 로고에
+            사용된 메인 색상은 Windows 10의 테마의 색상에서 영감을 얻었고
+            &quot;DEF:CON CRAB&quot;과 세미콜론(;)은 우리의 메인 테마 컬러를
+            입혀 단조로울 수 있는 텍스트 중심의 로고에 포인트 요소가 되었습니다.
+          </p>
+        </LogoIntroContents>
+        <BackgroundCard
+          color="#00658F"
+          height="22rem"
+          translateX="-1000px"
+          translateY="140px"
+          type="bordered"
+        />
+      </LogoIntroContainer>
     </LogoIntroWrapper>
   );
 };
 
 const LogoIntroWrapper = styled.div`
   height: 100vh;
-  margin-bottom: 10vh;
   display: flex;
-  @media screen and (min-width: 1280px) {
-    flex-direction: row;
-  }
-  flex-direction: column;
   justify-content: center;
   align-items: center;
   font-family: "Noto Sans KR";
 `;
 
-const LogoIntroContents = styled.div`
+const LogoIntroContainer = styled.div`
+  width: 80%;
   display: flex;
   flex-direction: column;
-  @media screen and (min-width: 1280px) {
-    justify-content: flex-start;
-    align-items: flex-start;
-  }
-  justify-content: center;
-  align-items: center;
 `;
 
-const LogoIntroTitle = styled.h1`
+const LogoIntroTitle = styled.div`
   @media screen and (min-width: 1280px) {
-    font-size: 45pt;
-    letter-spacing: -5px;
-    text-align: left;
+    width: 50%;
   }
 
-  @media screen and (min-width: 768px) {
-    font-size: 40pt;
-    letter-spacing: -2px;
-  }
+  h1 {
+    @media screen and (min-width: 1280px) {
+      font-size: 45pt;
+      letter-spacing: -5px;
+      text-align: left;
+    }
 
-  font-size: 25pt;
-  letter-spacing: -2px;
-  text-align: center;
+    @media screen and (max-width: 768px) {
+      font-size: 40pt;
+      letter-spacing: -2px;
+      text-align: center;
+    }
+  }
 `;
 
 const LogoIntroImg = styled.img`
   @media screen and (min-width: 1280px) {
-    width: 25vw;
-    margin-top: 15vh;
+    width: 30rem;
   }
-  width: 70vw;
-  margin-top: 5vh;
+
+  @media screen and (max-width: 768px) {
+    width: 55vw;
+    margin-top: 5vh;
+  }
 `;
 
-const LogoIntroContext = styled.div`
+const LogoIntroContents = styled.div`
+  display: flex;
+
   @media screen and (min-width: 1280px) {
-    margin-top: 30vh;
     font-size: 15pt;
     font-weight: 100;
     text-align: right;
+
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 15vh;
   }
 
-  @media screen and (min-width: 768px) {
+  @media screen and (max-width: 768px) {
     font-size: 16pt;
     font-weight: 100;
     text-align: center;
+
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
-  p{
-    width: 85%;
+
+  p {
+    @media screen and (min-width: 1280px) {
+      width: 45%;
+      text-align: right;
+    }
+
+    @media screen and (max-width: 768px) {
+      width: 85%;
+      margin-top: 5vh;
+      text-align: center;
+    }
   }
-  
-  margin-top: 5vh;
-  font-size: 13pt;
-  font-weight: 100;
-  text-align: center;
 `;
 
 export default LogoIntro;


### PR DESCRIPTION
# Summary
- LogoIntro 섹션 구조 리팩토링
- CrabIntro 섹션 CSS 속성 조정
- 이전 PR에서 발생한 Designs 페이지 레이아웃 오류 해결

# Descriptions
- LogoIntro 섹션에서 margin 으로 조악하게 잡혀있던 레이아웃을 CSS flex 속성으로 변경
  - 그에 따른 컴포넌트 계층 구조 수정
- CrabIntro 섹션은 단순히 CSS 속성만 조정하여 해결
  - max-width: 768px 대응 추가
  - Description 부분의 width를 % -> vw 단위로 조정하여 해결

# Images
## Desktop
![Designs_Desktop](https://user-images.githubusercontent.com/47844901/220676399-162a9bfa-25c6-4062-aa75-211ca14f2b0f.png)

## Mobile
![Designs_Mobile](https://user-images.githubusercontent.com/47844901/220676479-946b4b3b-71d0-41bb-9ebe-9642c3546465.png)

