### PR TITLE
[FIX] 메인 페이지 새로고침 문제 개선

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [
+    [
+      "styled-components",
+      {
+        "ssr": true,
+        "displayName": true,
+        "preprocess": true
+      }
+    ]
+  ]
+}

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -22,15 +22,15 @@ const MainAwards = () => {
   const desktop = useMediaQuery({
     query: "(min-width:1280px)",
   });
-  const [isDesktop, setDesktop] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(true);
   const [mainEvent, setMainEvent] = useState(tmpEventData);
 
   useEffect(() => {
-    if (desktop) setDesktop(true);
+    if (!desktop) setIsDesktop(false);
     API.getMainEventData().then((apiResult: any) => {
       setMainEvent(apiResult);
     });
-  }, [desktop]);
+  }, [isDesktop]);
 
   return (
     <MainAwardsWrapper>

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -9,11 +9,11 @@ const MainTitle = () => {
   const desktop = useMediaQuery({
     query: "(min-width:1208px)",
   });
-  const [isDesktop, setDesktop] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(true);
 
   useEffect(() => {
-    if (desktop) setDesktop(true);
-  }, [desktop]);
+    if (!desktop) setIsDesktop(false);
+  }, [isDesktop]);
 
   return (
     <MainTitleStyle>

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -105,7 +105,6 @@ const TitleContentsStyle = styled.div`
     }
 
     @media screen and (max-width: 768px) {
-      width: 85vw;
       margin-top: 2vh;
       margin-bottom: 2vh;
       font-size: 15pt;


### PR DESCRIPTION
# Summary
메인 페이지에서 새로고침시 컴포넌트가 왼쪽으로 이동하는 문제를 개선했습니다.
# Description
- MainTitle 컴포넌트에서 paragraph의 width 속성 제거
- babelrc 파일 추가
- MainTitle 컴포넌트에서 isDesktop의 기본 값을 true로 설정
- MainAwards 컴포넌트에서 isDesktop의 기본 값을 true로 설정

#64 관련 코드를 작성한 이후 발생한 문제인 것 같습니다.