### PR TITLE
[FIX] Main 페이지 디테일 개선 1

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import Dbutton from "../../src/Common/Dbutton";
 import * as API from "../../src/Common/API";
 import { useState, useEffect } from "react";
-import { useMediaQuery } from "react-responsive";
 
 type MainEventData = {
   title: string;
@@ -18,148 +17,183 @@ const tmpEventData: MainEventData = {
 };
 
 const MainAwards = () => {
-  const desktop = useMediaQuery({
-    query: "(min-width:1280px)",
-  });
-  const [isDesktop, setIsDesktop] = useState(true);
   const [mainEvent, setMainEvent] = useState(tmpEventData);
 
   useEffect(() => {
-    if (!desktop) setIsDesktop(false);
     API.getMainEventData().then((apiResult: any) => {
       setMainEvent(apiResult);
     });
-  }, [isDesktop]);
+  });
 
   return (
     <MainAwardsWrapper>
-      <MainAwardsStyle>
-        <AwardsTitle>
-          <h1>{mainEvent.title}</h1>
-        </AwardsTitle>
-        <AwardsContents>
-          {isDesktop ? (
-            <AwardsContentsWrapper>
-              <AwardsContentsContext>
-                <p>{mainEvent.content}</p>
-                <AwardsButton>
-                  <Link
-                    href="https://github.com/yymin1022/SeoulHealing"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <Dbutton
-                      text={"SOUL REST GitHub"}
-                      textColor={"#FFFFFF"}
-                      textSize={20}
-                      width={15}
-                      height={3}
-                      btnColor={"#001E2E"}
-                      direction={"right"}
-                    />
-                  </Link>
-                </AwardsButton>
-              </AwardsContentsContext>
-              <AwardsImage src={mainEvent.image}></AwardsImage>
-            </AwardsContentsWrapper>
-          ) : (
-            <>
-              <AwardsImage src={mainEvent.image}></AwardsImage>
-              <AwardsContentsContext>
-                <p>{mainEvent.content}</p>
-                <AwardsButton>
-                  <Link
-                    href="https://github.com/yymin1022/SeoulHealing"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <Dbutton
-                      text={"SOUL REST GitHub"}
-                      textColor={"#FFFFFF"}
-                      textSize={20}
-                      width={15}
-                      height={3}
-                      btnColor={"#001E2E"}
-                      direction={"right"}
-                    />
-                  </Link>
-                </AwardsButton>
-              </AwardsContentsContext>
-            </>
-          )}
-        </AwardsContents>
-      </MainAwardsStyle>
+      <AwardsTitle>
+        <h1>{mainEvent.title}</h1>
+      </AwardsTitle>
+      <AwardsContents>
+            <AwardsContentsContext>
+              <p>{mainEvent.content}</p>
+              <AwardsButton>
+                <Link
+                  href="https://github.com/yymin1022/SeoulHealing"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <Dbutton
+                    text={"SOUL REST GitHub"}
+                    textColor={"#FFFFFF"}
+                    textSize={20}
+                    width={15}
+                    height={3}
+                    btnColor={"#001E2E"}
+                    direction={"right"}
+                  />
+                </Link>
+              </AwardsButton>
+            </AwardsContentsContext>
+            <AwardsImage src={mainEvent.image} />
+      </AwardsContents>
     </MainAwardsWrapper>
   );
 };
 
 const MainAwardsWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  width: 70vw;
   height: 100vh;
-  font-family: "Noto Sans KR";
-
-  @media screen and (min-width: 769px) {
-    margin-bottom: 200px;
-  }
-`;
-
-const MainAwardsStyle = styled.div`
   display: flex;
   flex-direction: column;
-  @media screen and (min-width: 769px) {
-    width: 80%;
-    justify-content: flex-end;
+  justify-content: center;
+  font-family: "Noto Sans KR";
+
+  @media screen and (min-width: 1280px) {
     align-items: flex-end;
   }
 
-  @media screen and (max-width: 768px) {
-    align-items: center; 
+  @media screen and (max-width: 1023px) {
+    margin-bottom: 200px;
+    align-items: center;
   }
 `;
 
 const AwardsTitle = styled.div`
-  @media screen and (min-width: 769px) {
-    width: 60%;
-    background: #00658F;
-    border-radius: 2rem 2rem 2rem 2rem;
-    box-shadow: 16px 64px 0 0 #35B6F7;
+  width: 50vw;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-end;
+
+  @media screen and (min-width: 1280px) {
+    background: #00658f;
+    border-radius: 2rem;
+    box-shadow: 16px 64px 0 0 #35b6f7;
   }
+
   h1 {
-    @media screen and (min-width: 769px) {
-      width: 90%;
+    @media screen and (min-width: 1280px) {
+      align-items: flex-end;
       text-align: right;
-      font-size: 55pt;
+      font-size: 53pt;
       letter-spacing: -7px;
       color: #fff;
-      
       padding: 96px 0 96px 32px;
-      margin-right: 32px;
+      margin-right: 15px;
     }
 
-    @media screen and (max-width: 768px) {
+    @media screen and (min-width: 1024px) and (max-width: 1279px) {
+      align-items: center;
       text-align: center;
-      font-size: 35pt;
+      font-size: 45pt;
       letter-spacing: -5px;
+    }
+
+    @media screen and (max-width: 1023px) {
+      text-align: center;
+      font-size: 32pt;
+      letter-spacing: -2px;
       color: #000;
     }
   }
 `;
 
-const AwardsImage = styled.img`
-  @media screen and (min-width: 769px) {
-    width: 600px;
-    height: 400px;
+const AwardsContents = styled.div`
+  display: flex;
+  font-weight: 100;
+  margin-top: -5rem;
+  @media screen and (min-width: 1280px) {
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
   }
 
-  @media screen and (max-width: 768px) {
-    width: 400px;
-    height: 250px;
+  @media screen and (max-width: 1279px) {
+    margin-top: 2vh;
+    flex-direction: column-reverse;
+    align-items: center;
   }
-  
-  margin-top: -64px;
-  border-radius: 20px;
+
+  p {
+    letter-spacing: -1px;
+    @media screen and (min-width: 1280px) {
+      flex: 3;
+      text-align: left;
+      font-size: 20pt;
+      margin-right: 220px;
+    }
+
+    @media screen and (min-width: 1024px) and (max-width: 1279px) {
+      text-align: center;
+      font-size: 20pt;
+      margin: 2rem 0 2rem 0;
+    }
+
+    @media screen and (min-width: 768px) and (max-width: 1023px) {
+      text-align: center;
+      font-size: 18pt;
+      margin: 2rem 0 2rem 0;
+    }
+
+    @media screen and (max-width: 768px) {
+      margin: 2rem 0 2rem 0;
+      text-align: center;
+      font-size: 16pt;
+    }
+  }
+`;
+
+const AwardsImage = styled.img`
+  border-radius: 2rem;
+  @media screen and (min-width: 1280px) {
+    flex: 1;
+    width: 500px;
+    height: 332px;
+  }
+
+  @media screen and (min-width: 1024px) and (max-width: 1279px) {
+    margin-top: 2vh;
+    width: 400px;
+    height: 266px;
+  }
+
+  @media screen and (max-width: 1023px) {
+    margin-top: 2vh;
+    width: 400px;
+    height: 266px;
+  }
+`;
+
+const AwardsContentsContext = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  @media screen and (min-width: 1280px) {
+    align-items: flex-start;
+    margin-right: 75px;
+  }
+
+  @media screen and (max-width: 1023px) {
+    align-items: center;
+  }
 `;
 
 const AwardsButton = styled.div`
@@ -167,63 +201,6 @@ const AwardsButton = styled.div`
   flex-direction: row;
   justify-content: center;
   margin-top: 0.5rem;
-`;
-
-const AwardsContents = styled.div`
-  display: flex;
-
-  @media screen and (min-width: 769px) {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  @media screen and (max-width: 768px) {
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-  }
-
-  margin-top: 2vh;
-
-  p {
-    font-weight: 100;
-    @media screen and (min-width: 769px) {
-      width: 80%;
-      text-align: left;
-      font-size: 18pt;
-    }
-
-    @media screen and (max-width: 768px) {
-      width: 100%;
-      margin-top: 5vh;
-      margin-bottom: 5vh;
-      text-align: center;
-      font-size: 15pt;
-    }
-  }
-`;
-
-const AwardsContentsWrapper = styled.div`
-  @media screen and (min-width: 769px) {
-    width: 100vw;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-  }
-`;
-
-const AwardsContentsContext = styled.div`
-  display: flex;
-  flex-direction: column;
-  @media screen and (min-width: 769px) {
-    align-items: flex-start;
-  }
-
-  @media screen and (max-width: 768px) {
-    align-items: center; 
-  }
 `;
 
 export default MainAwards;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -1,166 +1,189 @@
 import styled from "styled-components";
 import Link from "next/link";
 import Dbutton from "../../src/Common/Dbutton";
-import BackgroundCard from "../../src/Common/BackgroundCard";
 
 const MainHistory = () => {
   return (
     <MainHistoryWrapper>
-        <HistoryTitle>
-          <h1>
-            시작은 성보고 꼭대기
-            <br />
-            컴퓨터실에서부터
-          </h1>
-          <HistoryImage src={"/Images/defcon_history.jpeg"} />
-        </HistoryTitle>
-        <HistoryContents>
-          <HistoryContentsBackground>
-            <p>
-              DEF:CON은 성보고등학교 컴퓨터실에서 시작된 동아리로 소프트웨어를
-              좋아하는 학생들이 모여 재미있는 일을 하던 데에서 시작되었습니다.
-              학교 행사에도 적극적으로 참여해 우리가 좋아하는 것들을 다른
-              학생들과 나눴죠.
-            </p>
-            <HistoryButton>
-              <Link
-                href="https://play.google.com/store/apps/details?id=com.defcon.sungbo&hl=ko&gl=US"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Dbutton
-                  text={"성보고 App"}
-                  textColor={"#FFFFFF"}
-                  textSize={20}
-                  width={12}
-                  height={3}
-                  btnColor={"#001E2E"}
-                  direction={"left"}
-                />
-              </Link>
-              <Link
-                href="https://sungbo.sen.hs.kr/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Dbutton
-                  text={"성보고 알아보기"}
-                  textColor={"#FFFFFF"}
-                  textSize={20}
-                  width={12}
-                  height={3}
-                  btnColor={"#001E2E"}
-                  direction={"left"}
-                />
-              </Link>
-            </HistoryButton>
-          </HistoryContentsBackground>
-        </HistoryContents>
+      <HistoryTitle>
+        <h1>
+          시작은 성보고 꼭대기
+          <br />
+          컴퓨터실에서부터
+        </h1>
+      </HistoryTitle>
+      <HistoryContents>
+        <HistoryImage src={"/Images/defcon_history.jpeg"} />
+        <HistoryContentsBackground>
+          <p>
+            DEF:CON은 성보고등학교 컴퓨터실에서 시작된 동아리로 소프트웨어를
+            좋아하는 학생들이 모여 재미있는 일을 하던 데에서 시작되었습니다.
+            학교 행사에도 적극적으로 참여해 우리가 좋아하는 것들을 다른 학생들과
+            나눴죠.
+          </p>
+          <HistoryButton>
+            <Link
+              href="https://play.google.com/store/apps/details?id=com.defcon.sungbo&hl=ko&gl=US"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Dbutton
+                text={"성보고 App"}
+                textColor={"#FFFFFF"}
+                textSize={20}
+                width={12}
+                height={3}
+                btnColor={"#001E2E"}
+                direction={"left"}
+              />
+            </Link>
+            <Link
+              href="https://sungbo.sen.hs.kr/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Dbutton
+                text={"성보고 알아보기"}
+                textColor={"#FFFFFF"}
+                textSize={20}
+                width={12}
+                height={3}
+                btnColor={"#001E2E"}
+                direction={"left"}
+              />
+            </Link>
+          </HistoryButton>
+        </HistoryContentsBackground>
+      </HistoryContents>
     </MainHistoryWrapper>
   );
 };
 
 const MainHistoryWrapper = styled.div`
+  width: 70vw;
   height: 100vh;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   font-family: "Noto Sans KR";
-
-  @media screen and (min-width: 769px) {
-    width: 80%;
-    flex-direction: row;
-    margin-bottom: 200px;
-    margin-left: 64px;
-  }
-
-  @media screen and (max-width: 768px) {
-    flex-direction: column;
-    margin-top: 300px;
-  }
 `;
-
 
 const HistoryTitle = styled.div`
   display: flex;
-  flex-direction: column;
-  @media screen and (min-width: 1280px) {
-    align-items: flex-start;
-  }
-  align-items: center;
+  flex-direction: row;
+  justify-content: center;
+
   h1 {
     @media screen and (min-width: 1280px) {
-      width: 100%;
+      align-items: flex-start;
+      flex: 2;
       text-align: left;
       font-size: 55pt;
       letter-spacing: -7px;
     }
 
-    text-align: center;
-    font-size: 40pt;
-    letter-spacing: -5px;
+    @media screen and (min-width: 1024px) and (max-width: 1279px) {
+      align-items: center;
+      text-align: center;
+      font-size: 45pt;
+      letter-spacing: -5px;
+    }
 
-    @media screen and (max-width: 768px) {
-      margin-bottom: 3vh;
+    @media screen and (max-width: 1023px) {
+      text-align: center;
+      font-size: 32pt;
+      letter-spacing: -2px;
     }
   }
 `;
 
-const HistoryImage = styled.img`
+const HistoryContents = styled.div`
+  display: flex;
+  justify-content: center;
+  font-weight: 300;
+
   @media screen and (min-width: 1280px) {
-    width: 600px;
+    flex-direction: row;
+    align-items: center;
+    
   }
-  width: 400px;
-  margin-top: 2vh;
-  border-radius: 20px;
+
+  @media screen and (max-width: 1279px) {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  p {
+    @media screen and (min-width: 1280px) {
+      flex: 1;
+      text-align: right;
+      font-size: 20pt;
+      letter-spacing: -1px;
+      margin: 35px 40px 40px 40px;
+    }
+
+    @media screen and (min-width: 1024px) and (max-width: 1279px) {
+      margin: 2rem 0rem 2rem 0rem;
+      text-align: center;
+      font-size: 20pt;
+      letter-spacing: -1px;
+    }
+
+    @media screen and (min-width: 768px) and (max-width:1023px) {
+      font-size: 18pt;
+      margin: 2rem 0 2rem 0;
+      text-align: center;
+    }
+
+    @media screen and (max-width: 768px) {
+      text-align: center;
+      margin: 2rem 0 2rem 0;
+      font-size: 16pt;
+      letter-spacing: -1px;
+      
+    }
+    
+  }
+`;
+
+const HistoryImage = styled.img`
+  border-radius: 2rem;
+  @media screen and (min-width: 1280px) {
+    flex: 1;
+    width: 500px;
+  }
+
+  @media screen and (min-width: 1024px) and (max-width: 1279px) {
+    margin-top: 2vh;
+    width: 400px;
+  }
+
+  @media screen and (max-width: 1023px) {
+    margin-top: 2vh;
+    width: 400px;
+  }
 `;
 
 const HistoryButton = styled.div`
   display: flex;
   flex-direction: row;
-  @media screen and (min-width: 769px) {
-    justify-content: right;
-    padding: 0px 64px 64px 0px;
-  }
-  justify-content: center;
   margin: 0.5rem 0rem 0rem 0rem;
-`;
-
-const HistoryContents = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  @media screen and (min-width: 769px) {
-    align-items: flex-end;
-    margin: 192px 0 0 64px;
-    padding-right: 15px;
+  
+  @media screen and (min-width: 1280px) {
+    padding: 0px 35px 50px 0px;
+    justify-content: flex-end;
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 1279px) {
     justify-content: center;
-    align-items: center;
   }
-
-  p {
-    @media screen and (min-width: 769px) {
-      text-align: right;
-      font-size: 18pt;
-      margin-right: 0px;
-      padding: 64px 64px 16px 64px;
-    }
-
-    @media screen and (max-width: 768px) {
-      text-align: center;
-      font-size: 15pt;
-      margin: 64px 16px 64px 16px;
-    }
-    font-weight: 300;
-    
-  }
+  
 `;
 
 const HistoryContentsBackground = styled.div`
-  @media screen and (min-width: 769px) {
-    border-radius: 2rem 2rem 2rem 2rem;
+  @media screen and (min-width: 1280px) {
+    margin-left: 50px;
+    border-radius: 2rem;
     background-color: #c7e7ff;
   }
 `;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -100,7 +100,7 @@ const HistoryTitle = styled.div`
 const HistoryContents = styled.div`
   display: flex;
   justify-content: center;
-  font-weight: 300;
+  font-weight: 100;
 
   @media screen and (min-width: 1280px) {
     flex-direction: row;


### PR DESCRIPTION
# Summary
- #92 에서 제시된 개선점을 개선하였습니다.
- MainHistory, MainAwards 섹션을 담당하여 작업하였습니다.
- 모바일 UI 레이아웃의 MediaQuery를 조정하였습니다.

# Descriptions
- MainAwards에서 불필요한 useMediaQuery Hook을 제거하여 CSS MediaQuery로 변경하였습니다.
  - 컴포넌트의 위치를 변경하는 조건부 렌더링을 제거하였습니다.
- 모바일 UI 레이아웃에서 애매한 768px ~ 1024px 사이의 속성을 추가하였습니다.
- 불필요한 Wrapper, Container를 제거하며 전반적인 컴포넌트 계층구조를 개선하였습니다. 

# Images
## MainHistory - Desktop
<img width="1792" alt="스크린샷 2023-03-01 오후 6 02 21" src="https://user-images.githubusercontent.com/47844901/222092563-7ea14ee8-e27f-4e64-b369-45bfaf295d65.png">

## MainHistory - Mobile
<img width="767" alt="스크린샷 2023-03-01 오후 6 03 02" src="https://user-images.githubusercontent.com/47844901/222092745-363b1893-8a60-4720-8601-e99c4b9d3323.png">

## MainAwards - Desktop
<img width="1792" alt="스크린샷 2023-03-01 오후 6 03 27" src="https://user-images.githubusercontent.com/47844901/222092828-da2dd66e-a672-445a-aed3-71b1af992986.png">

## MainAwards - Mobile
<img width="694" alt="스크린샷 2023-03-01 오후 6 03 52" src="https://user-images.githubusercontent.com/47844901/222092930-d3c47b75-a01a-4b23-8a03-b6f649796cb4.png">
