### PR TITLE
[FIX] Main 페이지 디테일 개선 2

### DIFF
--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 
 const MainTitle = () => {
   const desktop = useMediaQuery({
-    query: "(min-width:1208px)",
+    query: "(min-width:1280px)",
   });
   const [isDesktop, setIsDesktop] = useState(true);
 
@@ -57,7 +57,7 @@ const MainTitleStyle = styled.div`
 
 const TitleContentsStyle = styled.div`
   display: flex;
-  margin-top: 20px;
+  margin: 20px 50px 0 50px;
 
   @media screen and (min-width: 1280px) {
     flex-direction: row;
@@ -65,7 +65,7 @@ const TitleContentsStyle = styled.div`
     justify-content: center;
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 1279px) {
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -79,7 +79,7 @@ const TitleContentsStyle = styled.div`
       font-size: 70pt;
     }
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 1279px) {
       font-size: 40pt;
     }
   }
@@ -92,7 +92,7 @@ const TitleContentsStyle = styled.div`
       font-size: 25pt;
     }
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 1279px) {
       font-size: 15pt;
     }
   }
@@ -104,7 +104,7 @@ const TitleContentsStyle = styled.div`
       font-size: 20pt;
     }
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 1279px) {
       margin-top: 2vh;
       margin-bottom: 2vh;
       font-size: 15pt;
@@ -139,7 +139,7 @@ const ScrollIconStyle = styled.div`
     margin-top: 180px;
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 1279px) {
     margin-top: 50px;
   }
   transform: translatey(0px);

--- a/pages/Main/MainWorks.tsx
+++ b/pages/Main/MainWorks.tsx
@@ -43,11 +43,11 @@ const MainWorks = () => {
           </p>
         </WorksTitle>
         <ScrollMenuWrapper>
-          <ScrollMenu>
+          <StyledScrollMenu>
             {testArray.map((items) => (
               <WorksCard key={items.id} text={items.text} image={items.image} />
             ))}
-          </ScrollMenu>
+          </StyledScrollMenu>
         </ScrollMenuWrapper>
       </MainWorksContents>
     </MainWorksWrapper>
@@ -57,8 +57,10 @@ const MainWorks = () => {
 const MainWorksWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: center;
-  align-items: center;
+  @media screen and (max-width: 1279px) {
+    justify-content: center;
+    align-items: center; 
+  }
   width: 100vw;
   height: 100vh;
   margin-bottom: 200px;
@@ -67,16 +69,17 @@ const MainWorksWrapper = styled.div`
 const MainWorksContents = styled.div`
   display: flex;
   flex-direction: column;
-  @media screen and (min-width: 1280px) {
-    margin-left: 400px;
-  }
 `;
 
 const WorksTitle = styled.div`
   display: flex;
   flex-direction: column;
 
-  @media screen and (max-width: 768px) {
+  @media screen and (min-width: 1280px) {
+    margin-left: 32px;
+  }
+
+  @media screen and (max-width: 1279px) {
     justify-content: center;
     align-items: center;
   }
@@ -90,7 +93,7 @@ const WorksTitle = styled.div`
       letter-spacing: -7px;
     }
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 1279px) {
       font-size: 40pt;
       letter-spacing: -5px;
     }
@@ -105,7 +108,7 @@ const WorksTitle = styled.div`
       text-align: left;
     }
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: 1279px) {
       width: 85vw;
       margin-top: 5vh;
       font-size: 15pt;
@@ -115,11 +118,13 @@ const WorksTitle = styled.div`
 `;
 
 const ScrollMenuWrapper = styled.div`
-  @media screen and (min-width: 1280px) {
-    width: 70%;
-  }
-  width: 100%;
+  width: 100vw;
+  overflow-x: scroll;
   margin-top: 5vh;
+`;
+
+const StyledScrollMenu = styled(ScrollMenu)`
+  width: 100vw;
 `;
 
 export default MainWorks;


### PR DESCRIPTION
# Summary
MainTitle 컴포넌트의 데스크탑 기준 너비를 변경하고, MainWorks의 가로 스크롤 리스트를 개선했습니다.
# Description
- MainTitle, MainWorks에서 데스크탑 기준 너비를 1280px로 설정
- MainWorks에서 ScrollMenuWrapper의 스타일 수정
  - 모바일 화면에서도 가로 스크롤이 가능할 것으로 예상
# ScreenShot
<img width="366" alt="스크린샷 2023-03-01 오후 6 07 11" src="https://user-images.githubusercontent.com/10252712/222093743-50248bf2-570f-466d-b46e-af908aa374c8.png">
