### PR TITLE
[FIX] MainWorks 타이틀 위치 조정

### DIFF
--- a/pages/Main/MainWorks.tsx
+++ b/pages/Main/MainWorks.tsx
@@ -69,6 +69,7 @@ const MainWorksWrapper = styled.div`
 const MainWorksContents = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
 `;
 
 const WorksTitle = styled.div`
@@ -76,7 +77,7 @@ const WorksTitle = styled.div`
   flex-direction: column;
 
   @media screen and (min-width: 1280px) {
-    margin-left: 32px;
+    width: 70vw; 
   }
 
   @media screen and (max-width: 1279px) {


### PR DESCRIPTION
# Summary
MainWorks에서 타이틀의 위치를 조정했습니다.
# ScreenShot
<img width="1440" alt="스크린샷 2023-03-01 오후 6 53 45" src="https://user-images.githubusercontent.com/10252712/222104977-c9961197-a634-4d2a-b3e9-89e24c18b508.png">
