### PR TITLE
[FIX] Main 페이지 API 호출 Leak

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -23,7 +23,7 @@ const MainAwards = () => {
     API.getMainEventData().then((apiResult: any) => {
       setMainEvent(apiResult);
     });
-  });
+  }, []);
 
   return (
     <MainAwardsWrapper>


### PR DESCRIPTION
## Summary
- Main 페이지엑서 API 호출이 무한정 반복되던 문제를 해결하였습니다.

## Description
- Main 페이지의 MainAwards 컴포넌트에서 사용된 useEffect Hook이 원인이었습니다.
- Dependency 없이 useEffect Hook이 정의되어있었고, 그로인해 State가 변경되는 시점마다 재귀적으로 Hook이 작동하였고, 그로 인해서 불필요하게 과도한 API 트래픽이 발생하였습니다.
- 해당 useEffect Hook에 Empty Dependency를 적용하여 문제를 해결하였습니다.