### PR TITLE
[FIX] Project 페이지 이미지 렌더링 불가

### DIFF
--- a/pages/Projects/ProjectListItem.tsx
+++ b/pages/Projects/ProjectListItem.tsx
@@ -12,7 +12,7 @@ const ProjectListItem = (props: Props) => {
   return (
     <ListItemWrapper>
       <Link href={`Projects/${props.id}`}>
-        <ListItemImage alt="Project Image" src={`/${props.image}`} width={560} height={324} />
+        <ListItemImage alt="Project Image" src={props.image} width={560} height={324} />
         <ListItemTitle>{props.title}</ListItemTitle>
       </Link>
     </ListItemWrapper>

--- a/src/Common/ImageSlider.tsx
+++ b/src/Common/ImageSlider.tsx
@@ -22,7 +22,7 @@ const ImageSlider = (props: Props) => {
     <SliderStyle>
       <Slider {...settings} >
         {props.images.map((url, i) => (
-          <Image alt="Project Image" src={`/${url}`} key={i} width={600} height={450}/>
+          <Image alt="Project Image" src={url} key={i} width={600} height={450}/>
         ))}
       </Slider>
     </SliderStyle>


### PR DESCRIPTION
## Summary
- Project 페이지에서 이미지가 정상적으로 렌더링되지 않는 문제를 해결하였습니다.

## Description
- Project List 페이지에서 Project의 대표 이미지와, Project Detail 페이지에서 Project 상세 이미지들이 정상적으로 렌더링되지 않고 있었습니다.
- `Base64 String` 형식으로 이미지를 정의하였으나, 내부 코드에서 `URL` 형식으로 이미지를 렌더링 시도하여 찾지 못하는 문제가 발생했습니다.
- 해당하는 부분을 모두 `Base64 String` 형식으로 수행하도록 개선하였습니다.