### PR TITLE
[FIX] Main 페이지 CSS 리팩토링

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -72,7 +72,7 @@ const MainAwardsWrapper = styled.div`
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
     align-items: center;
-    margin-bottom: 25vh;
+    margin-bottom: 30vh;
   }
 `;
 

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -92,7 +92,7 @@ const AwardsTitle = styled.div`
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    width: 70vw;
+    width: 100%;
     align-items: center;
     h1 {
       text-align: center;
@@ -103,7 +103,6 @@ const AwardsTitle = styled.div`
 
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    width: 80vw;
     h1 {
       text-align: center;
       font-size: 2.3rem;

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -32,156 +32,138 @@ const MainAwards = () => {
         <h1>{mainEvent.title}</h1>
       </AwardsTitle>
       <AwardsContents>
-            <AwardsContentsContext>
-              <p>{mainEvent.content}</p>
-              <AwardsButton>
-                <Link
-                  href="https://github.com/yymin1022/SeoulHealing"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <Dbutton
-                    text={"SOUL REST GitHub"}
-                    textColor={"#FFFFFF"}
-                    textSize={20}
-                    width={15}
-                    height={3}
-                    btnColor={"#001E2E"}
-                    direction={"right"}
-                  />
-                </Link>
-              </AwardsButton>
-            </AwardsContentsContext>
-            <AwardsImage src={mainEvent.image} />
+        <AwardsContentsContext>
+          <p>{mainEvent.content}</p>
+          <AwardsButton>
+            <Link
+              href="https://github.com/yymin1022/SeoulHealing"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Dbutton
+                text={"SOUL REST GitHub"}
+                textColor={"#FFFFFF"}
+                textSize={20}
+                width={15}
+                height={3}
+                btnColor={"#001E2E"}
+                direction={"right"}
+              />
+            </Link>
+          </AwardsButton>
+        </AwardsContentsContext>
+        <AwardsImage src={mainEvent.image} />
       </AwardsContents>
     </MainAwardsWrapper>
   );
 };
 
 const MainAwardsWrapper = styled.div`
-  height: 100vh;
+  width: 65vw;
+  height: 68vh;
+  padding-top: 10rem;
+  margin-bottom: 30vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: flex-end;
   font-family: "Noto Sans KR";
 
-  @media screen and (min-width: 1280px) {
-    align-items: flex-end;
-    width: 70vw;
-  }
-
-  @media screen and (max-width: 1279px) {
-    margin-bottom: 200px;
-    width: 50vw;
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
     align-items: center;
+    margin-bottom: 25vh;
   }
 `;
 
 const AwardsTitle = styled.div`
-  width: 80%;
+  width: 60%;
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
 
-  @media screen and (min-width: 1280px) {
-    width: 50vw;
-    background: #00658f;
-    border-radius: 2rem;
-    box-shadow: 16px 64px 0 0 #35b6f7;
-
+  h1 {
+    text-align: right;
+    font-size: 5rem;
+    letter-spacing: -7px;
+    color: #000;
   }
 
-  h1 {
-    @media screen and (min-width: 1280px) {
-      align-items: flex-end;
-      text-align: right;
-      font-size: 53pt;
-      letter-spacing: -7px;
-      color: #fff;
-      padding: 96px 0 96px 32px;
-      margin-right: 15px;
-    }
-
-    @media screen and (min-width: 1024px) and (max-width: 1279px) {
-      align-items: center;
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    width: 70vw;
+    align-items: center;
+    h1 {
       text-align: center;
-      font-size: 45pt;
+      font-size: 4rem;
       letter-spacing: -5px;
     }
+  }
 
-    @media screen and (max-width: 1023px) {
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    width: 80vw;
+    h1 {
       text-align: center;
-      font-size: 32pt;
+      font-size: 2.3rem;
       letter-spacing: -2px;
-      color: #000;
     }
   }
 `;
 
 const AwardsContents = styled.div`
   display: flex;
+  flex:1;
   font-weight: 100;
-  margin-top: -5rem;
-  @media screen and (min-width: 1280px) {
-    flex-direction: row;
-    justify-content: space-evenly;
-    align-items: center;
-  }
-
-  @media screen and (max-width: 1279px) {
-    margin-top: 2vh;
-    flex-direction: column-reverse;
-    align-items: center;
-  }
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
   p {
+    width: 90%;
+    text-align: left;
+    font-size: 1.5rem;
     letter-spacing: -1px;
-    @media screen and (min-width: 1280px) {
-      flex: 3;
-      text-align: left;
-      font-size: 20pt;
-      margin-right: 220px;
-    }
+  }
 
-    @media screen and (min-width: 1024px) and (max-width: 1279px) {
-      text-align: center;
-      font-size: 20pt;
-      margin: 2rem 0 2rem 0;
-    }
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    flex-direction: column-reverse;
+    align-items: center;
 
-    @media screen and (min-width: 768px) and (max-width: 1023px) {
+    p {
+      margin: 3vh 0vh 3vh 0vh;
       text-align: center;
-      font-size: 18pt;
-      margin: 2rem 0 2rem 0;
+      font-size: 2rem;
     }
+  }
 
-    @media screen and (max-width: 768px) {
-      margin: 2rem 0 2rem 0;
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    p {
       text-align: center;
-      font-size: 16pt;
+      font-size: 1.2rem;
     }
   }
 `;
 
 const AwardsImage = styled.img`
   border-radius: 2rem;
-  @media screen and (min-width: 1280px) {
-    flex: 1;
-    width: 500px;
-    height: 332px;
+  flex: 1;
+  width:28vw;
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    border-radius: 1.5rem;
+    margin-top: 2vh;
+    width: 60vw;
   }
 
-  @media screen and (min-width: 1024px) and (max-width: 1279px) {
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
     margin-top: 2vh;
-    width: 400px;
-    height: 266px;
-  }
-
-  @media screen and (max-width: 1023px) {
-    margin-top: 2vh;
-    width: 350px;
-    height: 232px;
+    width: 70vw;
   }
 `;
 
@@ -189,14 +171,16 @@ const AwardsContentsContext = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: flex-start;
 
-  @media screen and (min-width: 1280px) {
-    align-items: flex-start;
-    margin-right: 75px;
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    align-items: center;
+    margin-right: 0;
   }
 
-  @media screen and (max-width: 1023px) {
-    align-items: center;
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
   }
 `;
 
@@ -204,7 +188,6 @@ const AwardsButton = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
-  margin-top: 0.5rem;
 `;
 
 export default MainAwards;

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -21,6 +21,7 @@ const MainAwards = () => {
 
   useEffect(() => {
     API.getMainEventData().then((apiResult: any) => {
+      console.log(apiResult);
       setMainEvent(apiResult);
     });
   }, []);
@@ -71,6 +72,7 @@ const MainAwardsWrapper = styled.div`
 
   @media screen and (max-width: 1279px) {
     margin-bottom: 200px;
+    width: 50vw;
     align-items: center;
   }
 `;

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -84,6 +84,7 @@ const AwardsTitle = styled.div`
   align-items: flex-end;
 
   h1 {
+    width: 80%;
     text-align: right;
     font-size: 5rem;
     letter-spacing: -7px;

--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -77,14 +77,14 @@ const MainAwardsWrapper = styled.div`
 `;
 
 const AwardsTitle = styled.div`
-  width: 60%;
+  width: 40vw;
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
 
   h1 {
-    width: 80%;
+    width: 100%;
     text-align: right;
     font-size: 5rem;
     letter-spacing: -7px;
@@ -93,7 +93,7 @@ const AwardsTitle = styled.div`
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    width: 100%;
+    width: 70vw;
     align-items: center;
     h1 {
       text-align: center;
@@ -105,6 +105,7 @@ const AwardsTitle = styled.div`
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
     h1 {
+      width: 100%;
       text-align: center;
       font-size: 2.3rem;
       letter-spacing: -2px;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -100,7 +100,6 @@ const HistoryTitle = styled.div`
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
     h1 {
-      text-align: center;
       font-size: 2.3rem;
       letter-spacing: -2px;
     }
@@ -116,7 +115,7 @@ const HistoryContents = styled.div`
   
 
   p {
-    flex: 3;
+    flex: 1;
     text-align: right;
     font-size: 1.5rem;
     letter-spacing: -1px;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -60,14 +60,18 @@ const MainHistory = () => {
 };
 
 const MainHistoryWrapper = styled.div`
+  width: 70vw;
   height: 100vh;
+  padding-top: 10rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: flex-start;
   font-family: "Noto Sans KR";
 
-  @media screen and (min-width: 1024px) {
-    width: 70vw;
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    align-items: center;
   }
 `;
 
@@ -77,24 +81,27 @@ const HistoryTitle = styled.div`
   justify-content: center;
 
   h1 {
-    @media screen and (min-width: 1280px) {
-      align-items: flex-start;
-      flex: 2;
-      text-align: left;
-      font-size: 55pt;
-      letter-spacing: -7px;
-    }
+    align-items: flex-start;
+    flex: 1;
+    text-align: left;
+    font-size: 5rem;
+    letter-spacing: -7px;
+  }
 
-    @media screen and (min-width: 1024px) and (max-width: 1279px) {
-      align-items: center;
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    h1 {
       text-align: center;
-      font-size: 45pt;
+      font-size: 4rem;
       letter-spacing: -5px;
     }
+  }
 
-    @media screen and (max-width: 1023px) {
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    h1 {
       text-align: center;
-      font-size: 32pt;
+      font-size: 2.2rem;
       letter-spacing: -2px;
     }
   }
@@ -102,45 +109,36 @@ const HistoryTitle = styled.div`
 
 const HistoryContents = styled.div`
   display: flex;
-  justify-content: center;
+  flex-direction: row;
+  align-items: center;
   font-weight: 100;
 
-  @media screen and (min-width: 1280px) {
-    flex-direction: row;
-    align-items: center;
+  p {
+    flex: 1;
+    text-align: right;
+    font-size: 1.5rem;
+    letter-spacing: -1px;
+    margin: 35px 40px 40px 40px;
   }
 
-  @media screen and (max-width: 1279px) {
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
     flex-direction: column;
     align-items: center;
+
+    p {
+      text-align: center;
+      font-size: 2rem;
+      letter-spacing: -1px;
+    }
   }
 
-  p {
-    @media screen and (min-width: 1280px) {
-      flex: 1;
-      text-align: right;
-      font-size: 20pt;
-      letter-spacing: -1px;
-      margin: 35px 40px 40px 40px;
-    }
-
-    @media screen and (min-width: 1024px) and (max-width: 1279px) {
-      margin: 2rem 0rem 2rem 0rem;
-      text-align: center;
-      font-size: 20pt;
-      letter-spacing: -1px;
-    }
-
-    @media screen and (min-width: 768px) and (max-width: 1023px) {
-      font-size: 18pt;
-      margin: 2rem 0 2rem 0;
-      text-align: center;
-    }
-
-    @media screen and (max-width: 768px) {
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    p {
       text-align: center;
       margin: 2rem 2rem 2rem 2rem;
-      font-size: 16pt;
+      font-size: 1.2rem;
       letter-spacing: -1px;
     }
   }
@@ -148,50 +146,47 @@ const HistoryContents = styled.div`
 
 const HistoryImage = styled.img`
   border-radius: 2rem;
-  @media screen and (min-width: 1280px) {
-    flex: 1;
-    width: 500px;
-  }
+  width: 28vw;
 
-  @media screen and (min-width: 1024px) and (max-width: 1279px) {
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
     margin-top: 2vh;
-    width: 400px;
+    width: 45vw;
   }
 
-  @media screen and (max-width: 1023px) {
-    margin-top: 2vh;
-    width: 400px;
-  }
-
-  @media screen and (max-width: 768px) {
-    width: 350px;
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    width: 60vw;
   }
 `;
 
 const HistoryButton = styled.div`
   display: flex;
   flex-direction: row;
+  justify-content: flex-end;
   margin: 0.5rem 0rem 0rem 0rem;
+  padding: 0rem 3rem 2rem 0rem;
 
-  @media screen and (min-width: 1280px) {
-    padding: 0px 35px 50px 0px;
-    justify-content: flex-end;
-  }
-
-  @media screen and (max-width: 1279px) {
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    padding: 0rem;
     justify-content: center;
   }
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
     margin: 1rem 1rem 0rem 1rem;
   }
 `;
 
 const HistoryContentsBackground = styled.div`
-  @media screen and (min-width: 1280px) {
-    margin-left: 50px;
-    border-radius: 2rem;
-    background-color: #c7e7ff;
+  width: 50%;
+  margin-left: 2rem;
+  
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    width: 90%;
+    margin-left: 0rem;
   }
 `;
 

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -73,6 +73,7 @@ const MainHistoryWrapper = styled.div`
 `;
 
 const HistoryTitle = styled.div`
+  width: 60vw;
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -87,6 +88,7 @@ const HistoryTitle = styled.div`
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    width: 80vw;
     align-items: center;
     h1 {
       text-align: center;
@@ -97,7 +99,6 @@ const HistoryTitle = styled.div`
 
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    width: 70vw;
     h1 {
       text-align: center;
       font-size: 2.3rem;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -16,10 +16,7 @@ const MainHistory = () => {
         <HistoryImage src={"/Images/defcon_history.jpeg"} />
         <HistoryContentsBackground>
           <p>
-            DEF:CON은 성보고등학교 컴퓨터실에서 시작된 동아리로 소프트웨어를
-            좋아하는 학생들이 모여 재미있는 일을 하던 데에서 시작되었습니다.
-            학교 행사에도 적극적으로 참여해 우리가 좋아하는 것들을 다른 학생들과
-            나눴죠.
+            DEF:CON은 성보고등학교 컴퓨터실에서 시작된 동아리로 소프트웨어를 좋아하는 학생들이 모여 재미있는 일을 하던 데에서 시작되었습니다. 학교 행사에도 적극적으로 참여해 우리가 좋아하는 것들을 다른 학생들과 나눴죠.
           </p>
           <HistoryButton>
             <Link
@@ -60,7 +57,7 @@ const MainHistory = () => {
 };
 
 const MainHistoryWrapper = styled.div`
-  width: 70vw;
+  width: 65vw;
   height: 100vh;
   padding-top: 10rem;
   display: flex;
@@ -78,10 +75,10 @@ const MainHistoryWrapper = styled.div`
 const HistoryTitle = styled.div`
   display: flex;
   flex-direction: row;
+  align-items: flex-start;
   justify-content: center;
 
   h1 {
-    align-items: flex-start;
     flex: 1;
     text-align: left;
     font-size: 5rem;
@@ -90,6 +87,7 @@ const HistoryTitle = styled.div`
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    align-items: center;
     h1 {
       text-align: center;
       font-size: 4rem;
@@ -99,9 +97,10 @@ const HistoryTitle = styled.div`
 
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    width: 70vw;
     h1 {
       text-align: center;
-      font-size: 2.2rem;
+      font-size: 2.3rem;
       letter-spacing: -2px;
     }
   }
@@ -110,15 +109,16 @@ const HistoryTitle = styled.div`
 const HistoryContents = styled.div`
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
   align-items: center;
   font-weight: 100;
+  
 
   p {
-    flex: 1;
+    flex: 3;
     text-align: right;
     font-size: 1.5rem;
     letter-spacing: -1px;
-    margin: 35px 40px 40px 40px;
   }
 
   @media screen and (max-width: 820px) {
@@ -127,6 +127,7 @@ const HistoryContents = styled.div`
     align-items: center;
 
     p {
+      margin: 2vh 0vh 2vh 0vh;
       text-align: center;
       font-size: 2rem;
       letter-spacing: -1px;
@@ -136,8 +137,8 @@ const HistoryContents = styled.div`
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
     p {
+      margin: 2vh 0vh 2vh 0vh;
       text-align: center;
-      margin: 2rem 2rem 2rem 2rem;
       font-size: 1.2rem;
       letter-spacing: -1px;
     }
@@ -150,13 +151,14 @@ const HistoryImage = styled.img`
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    border-radius: 1.5rem;
     margin-top: 2vh;
-    width: 45vw;
+    width: 60vw;
   }
 
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    width: 60vw;
+    width: 70vw;
   }
 `;
 
@@ -164,8 +166,6 @@ const HistoryButton = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  margin: 0.5rem 0rem 0rem 0rem;
-  padding: 0rem 3rem 2rem 0rem;
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -48,13 +48,13 @@ const MainTitle = () => {
 const MainTitleStyle = styled.div`
   font-family: "Noto Sans KR";
 
-  width: 90vw;
+  width:70vw;
   height: 100%;
 
   padding-top: 15rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-around;
   align-items: center;
 
   @media screen and (max-width: 820px) {
@@ -71,7 +71,7 @@ const MainTitleStyle = styled.div`
 `;
 
 const TitleContentsStyle = styled.div`
-  width: 65%;
+  /* width: 65%; */
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -86,6 +86,7 @@ const TitleContentsStyle = styled.div`
 `;
 
 const IntroStyle = styled.div`
+  margin-left: 10rem;
   padding-top: 2rem;
   text-align: right;
   p{
@@ -100,6 +101,7 @@ const IntroStyle = styled.div`
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    margin-left: 0rem;
     padding-top: 5rem;
     text-align: center;
     p{
@@ -114,6 +116,7 @@ const IntroStyle = styled.div`
 
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    margin-left: 0rem;
     text-align: center;
     p{
       font-size: 1.2rem;

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -13,28 +13,29 @@ const MainTitle = () => {
 
   useEffect(() => {
     if (!desktop) setIsDesktop(false);
-  }, [isDesktop]);
+    else setIsDesktop(true);
+  }, [desktop]);
 
   return (
     <MainTitleStyle>
       <TitleContentsStyle>
         <Crab
-          width={isDesktop ? 280 : 180}
-          height={isDesktop ? 280 : 180}
+          width={isDesktop ? 420 : 240}
+          height={isDesktop ? 420 : 240}
           marginTop={2}
           anim={true}
         />
         <IntroStyle>
           <p>&quot;이거 님이 만드신 거였군요!&quot;</p>
           <h1>TEAM DEF:CON</h1>
-          <p id="intro">
+          <IntroContents>
             당신의 일상 속 유용한 소프트웨어가
             <br />
             우리의 작품이었으면 좋겠습니다.
             <br />
             <br />
             2023년, 새로워진 대학생 프로그래밍팀 DEF:CON을 만나보세요.
-          </p>
+          </IntroContents>
         </IntroStyle>
       </TitleContentsStyle>
       <ScrollIconStyle>
@@ -45,84 +46,108 @@ const MainTitle = () => {
 };
 
 const MainTitleStyle = styled.div`
+  font-family: "Noto Sans KR";
+
+  width: 90vw;
+  height: 100%;
+
+  padding-top: 15rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  font-family: "Noto Sans KR";
-  height: 100vh;
-  margin-top: 50px;
-  margin-bottom: 200px; 
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    padding-top: 10rem;
+    height: 50%;
+  }
+
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    padding-top: 10rem;
+    height: 90vh;
+  }
 `;
 
 const TitleContentsStyle = styled.div`
+  width: 65%;
   display: flex;
-  margin: 20px 50px 0 50px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
-  @media screen and (min-width: 1280px) {
-    flex-direction: row;
-    text-align: right;
-    justify-content: center;
-  }
-
-  @media screen and (max-width: 1279px) {
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
     flex-direction: column;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
-    text-align: center;
-  }
-
-  h1 {
-    font-weight: bolder;
-    letter-spacing: -5px;
-    @media screen and (min-width: 1280px) {
-      font-size: 70pt;
-    }
-
-    @media screen and (max-width: 1279px) {
-      font-size: 40pt;
-    }
-  }
-
-  p {
-    font-weight: 300;
-    letter-spacing: -1px;
-
-    @media screen and (min-width: 1280px) {
-      font-size: 25pt;
-    }
-
-    @media screen and (max-width: 1279px) {
-      font-size: 15pt;
-    }
-  }
-
-  #intro {
-    font-weight: 300;
-
-    @media screen and (min-width: 1280px) {
-      font-size: 20pt;
-    }
-
-    @media screen and (max-width: 1279px) {
-      margin-top: 2vh;
-      margin-bottom: 2vh;
-      font-size: 15pt;
-    }
   }
 `;
 
 const IntroStyle = styled.div`
-  letter-spacing: 0.1rem;
-  @media screen and (min-width: 1280px) {
-    margin: 5px 0px 0px 100px;
-    font-size: 25px;
+  padding-top: 2rem;
+  text-align: right;
+  p{
+    font-size: 1.5rem;
+    font-weight: 100;
   }
-  margin: 100px 0px 0px 0px;
-  font-size: 10px;
+  h1 {
+    font-size: 6rem;
+    font-weight: 900;
+    letter-spacing: -0.1rem;
+  }
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    padding-top: 5rem;
+    text-align: center;
+    p{
+      font-size: 1.5rem;
+    }
+
+    h1{
+      font-size: 5rem;
+    }
+  }
+
+
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    text-align: center;
+    p{
+      font-size: 1.2rem;
+    }
+
+    h1{
+      font-size: 4rem;
+    }
+  }
+`;
+
+const IntroContents = styled.div`
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 100;
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    width: 80vw;
+    font-size: 2rem;
+    line-height: 2.5rem;
+  }
+
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    width: 75vw;
+    font-size: 1.2rem;
+    line-height: 1.5rem;
+  }
+  
 `;
 
 const ScrollIconStyle = styled.div`
+  padding-top: 15rem;
   @keyframes float {
     0% {
       transform: translatey(0px);
@@ -135,15 +160,18 @@ const ScrollIconStyle = styled.div`
     }
   }
 
-  @media screen and (min-width: 1280px) {
-    margin-top: 180px;
-  }
-
-  @media screen and (max-width: 1279px) {
-    margin-top: 50px;
-  }
   transform: translatey(0px);
   animation: float 2s ease-in-out infinite;
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    padding-top: 5rem;
+  }
+
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    padding-top: 3rem;
+  }
 `;
 
 export default MainTitle;

--- a/pages/Main/MainWorks.tsx
+++ b/pages/Main/MainWorks.tsx
@@ -39,7 +39,8 @@ const MainWorks = () => {
           <p>
             우리 DEF:CON이 관심을 갖고 즐겨온 일들의 카테고리입니다.
             <br />
-            소프트웨어가 사용될 수 있다면 우리는 뭐든 재미있게 갖고 놀 수 있습니다.
+            소프트웨어가 사용될 수 있다면 우리는 뭐든 재미있게 갖고 놀 수
+            있습니다.
           </p>
         </WorksTitle>
         <ScrollMenuWrapper>
@@ -55,77 +56,99 @@ const MainWorks = () => {
 };
 
 const MainWorksWrapper = styled.div`
+  width: 65vw;
+  height: 80vh;
   display: flex;
   flex-direction: row;
-  @media screen and (max-width: 1279px) {
-    justify-content: center;
-    align-items: center; 
+  justify-content: center;
+  align-items: flex-start;
+  margin: 10vh 0vh 20vh 0vh;
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    margin: 10vh 0vh 10vh 0vh;
   }
-  width: 100vw;
-  height: 100vh;
-  margin-bottom: 200px;
 `;
 
 const MainWorksContents = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 `;
 
 const WorksTitle = styled.div`
   display: flex;
   flex-direction: column;
-
-  @media screen and (min-width: 1280px) {
-    width: 70vw; 
-  }
-
-  @media screen and (max-width: 1279px) {
-    justify-content: center;
-    align-items: center;
-  }
+  align-items: flex-start;
 
   h1 {
-    text-align: center;
-
-    @media screen and (min-width: 1280px) {
-      text-align: left;
-      font-size: 55pt;
-      letter-spacing: -7px;
-    }
-
-    @media screen and (max-width: 1279px) {
-      font-size: 40pt;
-      letter-spacing: -5px;
-    }
+    text-align: left;
+    font-size: 5rem;
+    letter-spacing: -7px;
   }
 
   p {
-    font-weight: 300;
+    width: 100%;
+    font-weight: 100;
+    margin-top: 2vh;
+    font-size: 1.5rem;
+    text-align: left;
+  }
 
-    @media screen and (min-width: 1280px) {
-      margin-top: 2vh;
-      font-size: 18pt;
-      text-align: left;
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+
+    h1 {
+      text-align: center;
+      font-size: 4rem;
+      letter-spacing: -5px;
     }
 
-    @media screen and (max-width: 1279px) {
-      width: 85vw;
-      margin-top: 5vh;
-      font-size: 15pt;
+    p {
+      width: 100%;
+      margin: 3vh 0vh 3vh 0vh;
+      font-size: 2rem;
       text-align: center;
+    }
+  }
+
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    h1 {
+      text-align: center;
+      font-size: 2.3rem;
+      letter-spacing: -2px;
+    }
+
+    p {
+      text-align: center;
+      font-size: 1.2rem;
     }
   }
 `;
 
 const ScrollMenuWrapper = styled.div`
-  width: 100vw;
+  width: 80vw;
+  margin-left: -5vw;
   overflow-x: scroll;
   margin-top: 5vh;
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    width: 80vw;
+  }
+
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    width: 80vw;
+  }
 `;
 
 const StyledScrollMenu = styled(ScrollMenu)`
-  width: 100vw;
+  width: 100%;
 `;
 
 export default MainWorks;


### PR DESCRIPTION
## Summary
- 중구난방이었던 CSS 속성을 가다듬었습니다.
- 디자인 요소 Rectangle을 삭제하였습니다.
- MainAward 섹션에 데이터를 추가하였습니다.

## Descriptions
- min-width 기준으로 잡혀있던 media query를 iPad Air (820 * 1180), iPhone XR (414 * 896) max-width를 기준으로 하여 작성하였습니다.
- 화면에 따라 유연하게 적용되도록 폰트 및 마진 단위에서 pt, px 사용을 지양하고 rem 및 뷰포트 단위로 가다듬었습니다.
- MainAwards 데이터가 빈곤하길래 데이터를 삽입하여 UI를 다시 가다듬었습니다.

## Images
### Desktop
![defcon-desktop](https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/c12a380f-6fa2-42d3-ae5d-a0721133ac28)

### iPad Air (820 * 1180)
![defcon-tablet](https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/3260f875-e6c2-41b5-a699-be8fe8f480e8)

### iPhone XR (414 & 896)
![defcon-mobile](https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/fbd39c98-54e6-46e1-af9f-2961159b5db0)


