### PR TITLE
[FIX] Projects 상세 보기 페이지 CSS 스타일 리팩토링

### DIFF
--- a/pages/Projects/[ProjectDetail].tsx
+++ b/pages/Projects/[ProjectDetail].tsx
@@ -7,28 +7,29 @@ import styled from "styled-components";
 import * as API from "../../src/Common/API";
 import ImageSlider from "../../src/Common/ImageSlider";
 
-const ProjectDetail = ()=> {
+const ProjectDetail = () => {
   const router = useRouter();
   const projectId = router.query.ProjectDetail;
   const [projectData, setProjectData] = useState<API.ProjectData>();
 
   useEffect(() => {
-    if(projectId !== undefined) {
+    if (projectId !== undefined) {
       API.getProjectData(projectId as string).then((apiResult: any) => {
         setProjectData(apiResult);
       });
     }
   }, [projectId]);
 
-  if (!projectData) return (
-    <ProjectDetailWrapper>
-      <ProjectDetailTitle>
-        <h1>Page Not Found</h1>
-      </ProjectDetailTitle>
-    </ProjectDetailWrapper>
-  );
+  if (!projectData)
+    return (
+      <ProjectDetailWrapper>
+        <ProjectDetailTitle>
+          <h1>Page Not Found</h1>
+        </ProjectDetailTitle>
+      </ProjectDetailWrapper>
+    );
 
-  return(
+  return (
     <ProjectDetailWrapper>
       <div>
         <ProjectDetailTitle>
@@ -36,26 +37,30 @@ const ProjectDetail = ()=> {
           <p>{projectData.description}</p>
         </ProjectDetailTitle>
         <ProjectDetailContent>
-          <ImageSlider
-            images={projectData.image} />
+          <ImageSlider images={projectData.image} />
           <br></br>
 
           <ReactMarkdown
             rehypePlugins={[RehypeRaw]}
-            remarkPlugins={[RemarkGFM]}>
+            remarkPlugins={[RemarkGFM]}
+          >
             {projectData.content.toString().replaceAll("\\n", "\n")}
           </ReactMarkdown>
           <br></br>
 
           <h1>Tech Stack</h1>
           {projectData.tech.map((item, i) => {
-            return <p key={i}>{item}</p>
+            return <p key={i}>{item}</p>;
           })}
           <br></br>
 
           <h1>Role</h1>
           {projectData.user.map((item, i) => {
-            return <p key={i}><b>{item.user}</b> - {item.role}</p>
+            return (
+              <p key={i}>
+                <b>{item.user}</b> - {item.role}
+              </p>
+            );
           })}
           <br></br>
 
@@ -65,91 +70,109 @@ const ProjectDetail = ()=> {
         </ProjectDetailContent>
       </div>
     </ProjectDetailWrapper>
-  )
-}
+  );
+};
 
 const ProjectDetailWrapper = styled.div`
   font-family: "Noto Sans KR";
   min-height: 100vh;
   display: flex;
   justify-content: center;
+  align-items: center;
+
+  & > div {
+    width: 1030px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 20vh;
+  }
 `;
 
 const ProjectDetailTitle = styled.div`
-  margin-top: 128px;
+  margin-top: 200px;
+  margin-bottom: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+
   @media all and (min-width: 1280px) {
-    width: 1280px;
+    width: 100%;
     & > h1 {
+      width: 100%;
       text-align: left;
-      margin-left: 0.5rem;
-      font-size: 55pt;
+      font-size: 3.5em;
     }
     & > p {
-      margin: 1.5rem 0 1.5rem 0.5rem;
-      font-size: 18pt;
+      margin-top: 1rem;
+      font-size: 1.5rem;
       font-weight: 300;
     }
   }
 
-  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
-  @media all and (min-width:1024px) and (max-width:1279px) {
-    width: 1024px;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 700px;
     & > h1 {
+      width: 100%;
       text-align: left;
-      margin-left: 0.5rem;
-      font-size: 50pt;
+      font-size: 2.8rem;
     }
+
     & > p {
-      margin: 1.5rem 0 1.5rem 0.5rem;
-      font-size: 16pt;
+      margin-top: 1rem;
+      font-size: 1.313em;
       font-weight: 300;
     }
-  }   
+  }
 
-  /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
-  @media all and (min-width:768px) and (max-width:1023px) {
-    width: 768px;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 500px;
+    align-items: center;
     & > h1 {
+      width: 100%;
       text-align: center;
-      margin-left: 0.5rem;
-      font-size: 45pt;
+      font-size: 3.5em;
     }
     & > p {
       text-align: center;
-      margin: 1.5rem 0 1.5rem 0.5rem;
-      font-size: 14pt;
+      margin-top: 1rem;
+      font-size: 1.313em;
       font-weight: 300;
     }
-  } 
+  }
 
-  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
-  @media all and (min-width:480px) and (max-width:767px) {
-    width: 480px;
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 400px;
+    align-items: center;
     & > h1 {
-      text-alitn: center;
-      margin-left: 0.5rem;
-      font-size: 40pt;
+      text-align: center;
+      font-size: 3.2em;
     }
     & > p {
       text-align: center;
-      margin: 1.5rem 0 1.5rem 0.5rem;
-      font-size: 12pt;
+      margin-top: 1rem;
+      font-size: 1.17rem;
       font-weight: 300;
     }
-  } 
+  }
 
-  /* 모바일 세로 (해상도 ~ 479px)*/ 
-  @media all and (max-width:479px) {
-    width: 360px;
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 400px;
+    align-items: center;
     & > h1 {
-      text-alitn: center;
-      margin-left: 0.5rem;
-      font-size: 35pt;
+      text-align: center;
+      font-size: 2.9em;
     }
     & > p {
       text-align: center;
       margin: 1.5rem 0 1.5rem 0.5rem;
-      font-size: 12pt;
+      font-size: 1.17em;
       font-weight: 300;
     }
   }

--- a/pages/Projects/[ProjectDetail].tsx
+++ b/pages/Projects/[ProjectDetail].tsx
@@ -88,6 +88,13 @@ const ProjectDetailWrapper = styled.div`
     align-items: center;
     margin-bottom: 20vh;
   }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (max-width: 767px) {
+    & > div {
+      margin-bottom: 10vh;
+    }
+  }
 `;
 
 const ProjectDetailTitle = styled.div`
@@ -165,13 +172,14 @@ const ProjectDetailTitle = styled.div`
   @media all and (max-width: 479px) {
     width: 400px;
     align-items: center;
+    margin-top: 7em;
     & > h1 {
       text-align: center;
       font-size: 2.9em;
     }
     & > p {
       text-align: center;
-      margin: 1.5rem 0 1.5rem 0.5rem;
+      margin: 1.5rem 0 0 0.5rem;
       font-size: 1.17em;
       font-weight: 300;
     }
@@ -179,10 +187,80 @@ const ProjectDetailTitle = styled.div`
 `;
 
 const ProjectDetailContent = styled.div`
+  width: 100%;
+  margin-top: 1em;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-align: center;
+
+  a {
+    font-weight: 900;
+    text-decoration-line: underline;
+  }
+
+
+  @media all and (min-width: 1280px) {
+    & > h1 {
+      margin-top: 1em;
+      font-size: 2.9em;
+    }
+
+    & > p {
+      width: 80%;
+      font-size: 1.5em;
+      font-weight: 100;
+    }
+  }
+
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1279px) {
+    width: 80%;
+    & > h1 {
+      margin-top: 1em;
+      font-size: 2.9em;
+    }
+
+    & > p {
+      width: 80%;
+      font-size: 1.5em;
+      font-weight: 100;
+    }
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 70%;
+    & > h1 {
+      margin-top: 1em;
+      font-size: 2.9em;
+    }
+
+    & > p {
+      width: 100%;
+      font-size: 1.5em;
+      font-weight: 100;
+      margin-bottom: 0.5em;
+    }
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 70%;
+    & > h1 {
+      margin-top: 0.5em;
+      font-size: 2.9em;
+    }
+
+    & > p {
+      width: 100%;
+      font-size: 1.5em;
+      font-weight: 100;
+      margin-bottom: 0.5em;
+    }
+  }
 `;
 
 export default ProjectDetail;


### PR DESCRIPTION
## Summary
- Projects 상세 보기 페이지의 CSS 스타일을 리팩토링하였습니다.

## Descriptions
- 다음과 같은 화면 너비 기준으로 미디어 쿼리를 작성하였습니다.
  - 1280px 이상 - 데스크탑 기준
  - 1024px ~ 1279px - 노트북 & 태블릿 가로 화면 기준
  - 768px ~ 1023px - 태블릿 가로 화면 기준
  - 480px ~ 767px - 모바일 가로 & 태블릿 세로 화면 기준
  - ~ 479px - 기타 모바일 세로 화면 기준
- 요청대로 너비를 px 단위로 고정 후 자식 요소들에 대한 크기는 em및 % 단위를 활용하여 반응형으로 동작할 수 있도록 구성하였습니다.
- 크기는 LGTM인데 맘에 안들면 말하지 마세요. 히히
- 자세한 상태는 첨부한 이미지를 확인해주세요.

## Images
### 1280px 이상
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/b33656e2-f577-45f6-9396-63abaa271776" width="300"/>

### 1024px ~ 1279px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/c2a632b5-3f4d-480c-a11f-3fb7929a1d06" width="300"/>

### 768px ~ 1023px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/d206dc66-c555-4139-9e08-2fd66e319017" width="300"/>

### 480px ~ 767px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/0db8d062-f6c6-4c6a-be44-caaaf97dc103" width="300"/>

### ~ 479px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/4c7a4bce-b69e-4099-a8b3-3871920bb97a" width="300"/>
