### PR TITLE
[FIX] Main 페이지 CSS 스타일 리팩토링

### DIFF
--- a/pages/Main/MainAwards.tsx
+++ b/pages/Main/MainAwards.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Dbutton from "../../src/Common/Dbutton";
 import * as API from "../../src/Common/API";
 import { useState, useEffect } from "react";
+import { useMediaQuery } from "react-responsive";
 
 type MainEventData = {
   title: string;
@@ -17,7 +18,16 @@ const tmpEventData: MainEventData = {
 };
 
 const MainAwards = () => {
+  const desktop = useMediaQuery({
+    query: "(min-width:1280px)",
+  });
   const [mainEvent, setMainEvent] = useState(tmpEventData);
+  const [isDesktop, setIsDesktop] = useState(true);
+
+  useEffect(() => {
+    if (!desktop) setIsDesktop(false);
+    else setIsDesktop(true);
+  }, [desktop]);
 
   useEffect(() => {
     API.getMainEventData().then((apiResult: any) => {
@@ -43,8 +53,8 @@ const MainAwards = () => {
               <Dbutton
                 text={"SOUL REST GitHub"}
                 textColor={"#FFFFFF"}
-                textSize={20}
-                width={15}
+                textSize={isDesktop ? 20 : 18}
+                width={isDesktop ? 15 : 11}
                 height={3}
                 btnColor={"#001E2E"}
                 direction={"right"}
@@ -59,112 +69,204 @@ const MainAwards = () => {
 };
 
 const MainAwardsWrapper = styled.div`
-  width: 65vw;
-  height: 68vh;
-  padding-top: 10rem;
-  margin-bottom: 30vh;
+  width: 1030px;
+  padding-top: 15rem;
+  margin-bottom: 5em;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
   font-family: "Noto Sans KR";
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    align-items: center;
-    margin-bottom: 30vh;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 700px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    padding-top: 8rem;
+    width: 500px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 400px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 400px;
   }
 `;
 
 const AwardsTitle = styled.div`
-  width: 40vw;
+  width: 60%;
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
 
-  h1 {
-    width: 100%;
+  & > h1 {
+    flex: 1;
     text-align: right;
-    font-size: 5rem;
+    font-size: 4.5em;
     letter-spacing: -7px;
-    color: #000;
   }
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    width: 70vw;
-    align-items: center;
-    h1 {
-      text-align: center;
-      font-size: 4rem;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    & > h1 {
+      flex: 1;
+      text-align: right;
+      font-size: 2.8em;
       letter-spacing: -5px;
     }
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    h1 {
-      width: 100%;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 100%;
+
+    & > h1 {
       text-align: center;
-      font-size: 2.3rem;
+      font-size: 3.5em;
+      letter-spacing: -5px;
+    }
+  }
+
+  /* 모바일 가로 & 세로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 100%;
+
+    & > h1 {
+      text-align: center;
+      font-size: 3em;
+      letter-spacing: -2px;
+    }
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 100%;
+
+    & > h1 {
+      text-align: center;
+      font-size: 2.5em;
       letter-spacing: -2px;
     }
   }
 `;
 
 const AwardsContents = styled.div`
+  width: 100%;
   display: flex;
-  flex:1;
-  font-weight: 100;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
 
   p {
     width: 90%;
+    flex: 1;
     text-align: left;
-    font-size: 1.5rem;
+    font-size: 1.5em;
+    line-height: 1.5em;
     letter-spacing: -1px;
+    font-weight: 100;
+    margin-bottom: 1em;
   }
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    flex-direction: column-reverse;
-    align-items: center;
-
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
     p {
-      margin: 3vh 0vh 3vh 0vh;
-      text-align: center;
-      font-size: 2rem;
+      flex: 1;
+      text-align: left;
+      font-size: 1em;
+      line-height: 1.5em;
+      letter-spacing: -1px;
+      font-weight: 100;
+      margin-bottom: 1em;
     }
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    height: 80%;
+    flex-direction: column-reverse;
+
     p {
+      flex: 1;
       text-align: center;
-      font-size: 1.2rem;
+      font-size: 1.5em;
+      line-height: 1.5em;
+      letter-spacing: -1px;
+      font-weight: 100;
+      padding-top: 1em;
+    }
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    height: 80%;
+    flex-direction: column-reverse;
+
+    p {
+      flex: 1;
+      text-align: center;
+      font-size: 1.5em;
+      line-height: 1.5em;
+      letter-spacing: -1px;
+      font-weight: 100;
+      padding-top: 1em;
+    }
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    height: 80%;
+    flex-direction: column-reverse;
+
+    p {
+      flex: 1;
+      text-align: center;
+      font-size: 1.2em;
+      line-height: 1em;
+      letter-spacing: -1px;
+      font-weight: 100;
+      padding-top: 1em;
     }
   }
 `;
 
 const AwardsImage = styled.img`
   border-radius: 2rem;
-  flex: 1;
-  width:28vw;
+  width: 45%;
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    border-radius: 1.5rem;
-    margin-top: 2vh;
-    width: 60vw;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    border-radius: 1em;
+    width: 50%;
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    margin-top: 2vh;
-    width: 70vw;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    border-radius: 1.5em;
+    margin-top: 1em;
+    width: 90%;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    border-radius: 1.5em;
+    margin-top: 1em;
+    width: 90%;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    border-radius: 1em;
+    margin: 1em 0em 0.5em 0em;
+    width: 80%;
   }
 `;
 
@@ -179,16 +281,23 @@ const AwardsContentsContext = styled.div`
     align-items: center;
     margin-right: 0;
   }
-
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-  }
 `;
 
 const AwardsButton = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
+
+  @media screen and (max-width: 820px) {
+    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
+    padding: 0rem;
+    justify-content: center;
+  }
+
+  @media screen and (max-width: 414px) {
+    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+    margin: 1rem 1rem 0rem 1rem;
+  }
 `;
 
 export default MainAwards;

--- a/pages/Main/MainHistory.tsx
+++ b/pages/Main/MainHistory.tsx
@@ -1,8 +1,20 @@
 import styled from "styled-components";
 import Link from "next/link";
 import Dbutton from "../../src/Common/Dbutton";
+import { useState, useEffect } from "react";
+import { useMediaQuery } from "react-responsive";
 
 const MainHistory = () => {
+  const desktop = useMediaQuery({
+    query: "(min-width:1280px)",
+  });
+  const [isDesktop, setIsDesktop] = useState(true);
+
+  useEffect(() => {
+    if (!desktop) setIsDesktop(false);
+    else setIsDesktop(true);
+  }, [desktop]);
+
   return (
     <MainHistoryWrapper>
       <HistoryTitle>
@@ -16,7 +28,10 @@ const MainHistory = () => {
         <HistoryImage src={"/Images/defcon_history.jpeg"} />
         <HistoryContentsBackground>
           <p>
-            DEF:CON은 성보고등학교 컴퓨터실에서 시작된 동아리로 소프트웨어를 좋아하는 학생들이 모여 재미있는 일을 하던 데에서 시작되었습니다. 학교 행사에도 적극적으로 참여해 우리가 좋아하는 것들을 다른 학생들과 나눴죠.
+            DEF:CON은 성보고등학교 컴퓨터실에서 시작된 동아리로 소프트웨어를
+            좋아하는 학생들이 모여 재미있는 일을 하던 데에서 시작되었습니다.
+            학교 행사에도 적극적으로 참여해 우리가 좋아하는 것들을 다른 학생들과
+            나눴죠.
           </p>
           <HistoryButton>
             <Link
@@ -27,8 +42,8 @@ const MainHistory = () => {
               <Dbutton
                 text={"성보고 App"}
                 textColor={"#FFFFFF"}
-                textSize={20}
-                width={11}
+                textSize={isDesktop ? 20 : 18}
+                width={isDesktop ? 11 : 9}
                 height={3}
                 btnColor={"#001E2E"}
                 direction={"left"}
@@ -42,8 +57,8 @@ const MainHistory = () => {
               <Dbutton
                 text={"성보고 알아보기"}
                 textColor={"#FFFFFF"}
-                textSize={20}
-                width={11}
+                textSize={isDesktop ? 20 : 18}
+                width={isDesktop ? 11 : 9}
                 height={3}
                 btnColor={"#001E2E"}
                 direction={"left"}
@@ -57,108 +72,203 @@ const MainHistory = () => {
 };
 
 const MainHistoryWrapper = styled.div`
-  width: 65vw;
-  height: 100vh;
+  width: 1030px;
   padding-top: 10rem;
+  margin-bottom: 5em;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
   font-family: "Noto Sans KR";
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    align-items: center;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 700px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 500px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 400px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 400px;
   }
 `;
 
 const HistoryTitle = styled.div`
-  width: 60vw;
+  width: 60%;
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   justify-content: center;
 
-  h1 {
+  & > h1 {
     flex: 1;
     text-align: left;
-    font-size: 5rem;
+    font-size: 4.5em;
     letter-spacing: -7px;
   }
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    width: 80vw;
-    align-items: center;
-    h1 {
-      text-align: center;
-      font-size: 4rem;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    & > h1 {
+      flex: 1;
+      text-align: left;
+      font-size: 2.8em;
       letter-spacing: -5px;
     }
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    h1 {
-      font-size: 2.3rem;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 100%;
+
+    & > h1 {
+      text-align: center;
+      font-size: 3.5em;
+      letter-spacing: -5px;
+    }
+  }
+
+  /* 모바일 가로 & 세로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 100%;
+
+    & > h1 {
+      text-align: center;
+      font-size: 3em;
+      letter-spacing: -2px;
+    }
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 100%;
+
+    & > h1 {
+      text-align: center;
+      font-size: 2.5em;
       letter-spacing: -2px;
     }
   }
 `;
 
 const HistoryContents = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  font-weight: 100;
-  
 
   p {
     flex: 1;
     text-align: right;
-    font-size: 1.5rem;
+    font-size: 1.5em;
+    line-height: 1.5em;
     letter-spacing: -1px;
+    font-weight: 100;
+    margin-bottom: 1em;
   }
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    flex-direction: column;
-    align-items: center;
-
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
     p {
-      margin: 2vh 0vh 2vh 0vh;
-      text-align: center;
-      font-size: 2rem;
+      flex: 1;
+      text-align: right;
+      font-size: 1em;
+      line-height: 1.5em;
       letter-spacing: -1px;
+      font-weight: 100;
+      margin-bottom: 1em;
     }
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    height: 80%;
+    flex-direction: column;
+
     p {
-      margin: 2vh 0vh 2vh 0vh;
+      flex: 1;
       text-align: center;
-      font-size: 1.2rem;
+      font-size: 1.5em;
+      line-height: 1.5em;
       letter-spacing: -1px;
+      font-weight: 100;
+      padding-top:1em;
+    }
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    height: 80%;
+    flex-direction: column;
+
+    p {
+      flex: 1;
+      text-align: center;
+      font-size: 1.5em;
+      line-height: 1.5em;
+      letter-spacing: -1px;
+      font-weight: 100;
+      padding-top:1em;
+    }
+
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    height: 80%;
+    flex-direction: column;
+
+    p {
+      flex: 1;
+      text-align: center;
+      font-size: 1.2em;
+      line-height: 1em;
+      letter-spacing: -1px;
+      font-weight: 100;
+      padding-top: 1em;
     }
   }
 `;
 
 const HistoryImage = styled.img`
   border-radius: 2rem;
-  width: 28vw;
+  width: 45%;
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    border-radius: 1.5rem;
-    margin-top: 2vh;
-    width: 60vw;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    border-radius: 1em;
+    width: 50%;
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    width: 70vw;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    border-radius: 1.5em;
+    margin-top: 1em;
+    width: 90%;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    border-radius: 1.5em;
+    margin-top: 1em;
+    width: 90%;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    border-radius: 1em;
+    margin: 1em 0em 0.5em 0em;
+    width: 80%;
   }
 `;
 
@@ -182,7 +292,7 @@ const HistoryButton = styled.div`
 const HistoryContentsBackground = styled.div`
   width: 50%;
   margin-left: 2rem;
-  
+
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
     width: 90%;

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -39,7 +39,7 @@ const MainTitle = () => {
         </IntroWrapper>
       </TitleContentsStyle>
       <ScrollIconStyle>
-        <FontAwesomeIcon icon={faAngleDoubleDown} color="#4C6170" size="3x" />
+        <FontAwesomeIcon icon={faAngleDoubleDown} color="#4C6170" size={isDesktop ? "3x" : "2x"} />
       </ScrollIconStyle>
     </MainTitleStyle>
   );
@@ -82,22 +82,18 @@ const TitleContentsStyle = styled.div`
   align-items: center;
 
   @media all and (min-width: 1024px) and (max-width: 1279px) {
-    width: 700px;
   }
 
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/
   @media all and (min-width: 768px) and (max-width: 1023px) {
-    width: 500px;
   }
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
   @media all and (min-width: 480px) and (max-width: 767px) {
-    width: 400px;
   }
 
   /* 모바일 세로 (해상도 ~ 479px)*/
   @media all and (max-width: 479px) {
-    width: 400px;
   }
 
   @media screen and (max-width: 820px) {
@@ -125,6 +121,28 @@ const IntroWrapper = styled.div`
     letter-spacing: -0.1rem;
   }
 
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    & > p {
+      font-size: 1em;
+    }
+
+    & > h1 {
+      font-size: 3em;
+    }
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+  }
+
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
     margin-left: 0rem;
@@ -138,21 +156,7 @@ const IntroWrapper = styled.div`
       font-size: 5rem;
     }
   }
-
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    margin-left: 0rem;
-    text-align: center;
-    p {
-      font-size: 1.2rem;
-    }
-
-    h1 {
-      font-size: 4rem;
-    }
-  }
 `;
-
 
 const ScrollIconStyle = styled.div`
   padding-top: 15em;
@@ -170,6 +174,10 @@ const ScrollIconStyle = styled.div`
 
   transform: translatey(0px);
   animation: float 2s ease-in-out infinite;
+
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    padding-top: 10em;
+  }
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -53,6 +53,7 @@ const MainTitleStyle = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+
   /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
   @media all and (min-width: 1024px) and (max-width: 1279px) {
     width: 700px;
@@ -60,6 +61,7 @@ const MainTitleStyle = styled.div`
 
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/
   @media all and (min-width: 768px) and (max-width: 1023px) {
+    padding-top: 8rem;
     width: 500px;
   }
 
@@ -81,11 +83,10 @@ const TitleContentsStyle = styled.div`
   justify-content: space-evenly;
   align-items: center;
 
-  @media all and (min-width: 1024px) and (max-width: 1279px) {
-  }
-
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/
   @media all and (min-width: 768px) and (max-width: 1023px) {
+    flex-direction: column;
+    justify-content: center;
   }
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
@@ -94,13 +95,6 @@ const TitleContentsStyle = styled.div`
 
   /* 모바일 세로 (해상도 ~ 479px)*/
   @media all and (max-width: 479px) {
-  }
-
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
   }
 `;
 
@@ -124,6 +118,7 @@ const IntroWrapper = styled.div`
   @media all and (min-width: 1024px) and (max-width: 1279px) {
     & > p {
       font-size: 1em;
+      line-height: 1.5em;
     }
 
     & > h1 {
@@ -133,6 +128,11 @@ const IntroWrapper = styled.div`
 
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/
   @media all and (min-width: 768px) and (max-width: 1023px) {
+    margin-top: 1em;
+
+    & > p {
+      line-height: 1em;
+    }
   }
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
@@ -179,14 +179,9 @@ const ScrollIconStyle = styled.div`
     padding-top: 10em;
   }
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    padding-top: 5rem;
-  }
-
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    padding-top: 3rem;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    padding-top: 5em;
   }
 `;
 

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -39,7 +39,11 @@ const MainTitle = () => {
         </IntroWrapper>
       </TitleContentsStyle>
       <ScrollIconStyle>
-        <FontAwesomeIcon icon={faAngleDoubleDown} color="#4C6170" size={isDesktop ? "3x" : "2x"} />
+        <FontAwesomeIcon
+          icon={faAngleDoubleDown}
+          color="#4C6170"
+          size={isDesktop ? "3x" : "2x"}
+        />
       </ScrollIconStyle>
     </MainTitleStyle>
   );
@@ -49,6 +53,7 @@ const MainTitleStyle = styled.div`
   width: 1030px;
   font-family: "Noto Sans KR";
   padding-top: 10rem;
+  margin-bottom: 5em;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -83,18 +88,10 @@ const TitleContentsStyle = styled.div`
   justify-content: space-evenly;
   align-items: center;
 
-  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
-  @media all and (min-width: 768px) and (max-width: 1023px) {
+  /*(해상도 ~ 1023px)*/
+  @media all and (max-width: 1023px) {
     flex-direction: column;
     justify-content: center;
-  }
-
-  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
-  @media all and (min-width: 480px) and (max-width: 767px) {
-  }
-
-  /* 모바일 세로 (해상도 ~ 479px)*/
-  @media all and (max-width: 479px) {
   }
 `;
 
@@ -128,7 +125,8 @@ const IntroWrapper = styled.div`
 
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/
   @media all and (min-width: 768px) and (max-width: 1023px) {
-    margin-top: 1em;
+    margin-top: 5em;
+    text-align: center;
 
     & > p {
       line-height: 1em;
@@ -137,23 +135,30 @@ const IntroWrapper = styled.div`
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
   @media all and (min-width: 480px) and (max-width: 767px) {
+    margin-top: 5em;
+    text-align: center;
+
+    & > p {
+      font-size: 1.5em;
+      line-height: 1em;
+    }
+
+    & > h1 {
+      font-size: 4em;
+    }
   }
 
   /* 모바일 세로 (해상도 ~ 479px)*/
   @media all and (max-width: 479px) {
-  }
-
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    margin-left: 0rem;
-    padding-top: 5rem;
     text-align: center;
-    p {
-      font-size: 1.5rem;
+
+    & > p {
+      font-size: 1.2em;
+      line-height: 1em;
     }
 
-    h1 {
-      font-size: 5rem;
+    & > h1 {
+      font-size: 3em;
     }
   }
 `;
@@ -182,6 +187,16 @@ const ScrollIconStyle = styled.div`
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/
   @media all and (min-width: 768px) and (max-width: 1023px) {
     padding-top: 5em;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    padding-top: 3em;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    padding-top: 4em;
   }
 `;
 

--- a/pages/Main/MainTitle.tsx
+++ b/pages/Main/MainTitle.tsx
@@ -20,23 +20,23 @@ const MainTitle = () => {
     <MainTitleStyle>
       <TitleContentsStyle>
         <Crab
-          width={isDesktop ? 420 : 240}
-          height={isDesktop ? 420 : 240}
+          width={isDesktop ? 360 : 240}
+          height={isDesktop ? 360 : 240}
           marginTop={2}
           anim={true}
         />
-        <IntroStyle>
+        <IntroWrapper>
           <p>&quot;이거 님이 만드신 거였군요!&quot;</p>
           <h1>TEAM DEF:CON</h1>
-          <IntroContents>
+          <p>
             당신의 일상 속 유용한 소프트웨어가
             <br />
             우리의 작품이었으면 좋겠습니다.
             <br />
             <br />
             2023년, 새로워진 대학생 프로그래밍팀 DEF:CON을 만나보세요.
-          </IntroContents>
-        </IntroStyle>
+          </p>
+        </IntroWrapper>
       </TitleContentsStyle>
       <ScrollIconStyle>
         <FontAwesomeIcon icon={faAngleDoubleDown} color="#4C6170" size="3x" />
@@ -46,36 +46,59 @@ const MainTitle = () => {
 };
 
 const MainTitleStyle = styled.div`
+  width: 1030px;
   font-family: "Noto Sans KR";
-
-  width:70vw;
-  height: 100%;
-
-  padding-top: 15rem;
+  padding-top: 10rem;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
-
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    padding-top: 10rem;
-    height: 50%;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 700px;
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    padding-top: 10rem;
-    height: 90vh;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 500px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 400px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 400px;
   }
 `;
 
 const TitleContentsStyle = styled.div`
-  /* width: 65%; */
+  width: 100%;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-evenly;
   align-items: center;
+
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 700px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 500px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 400px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 400px;
+  }
 
   @media screen and (max-width: 820px) {
     // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
@@ -85,16 +108,19 @@ const TitleContentsStyle = styled.div`
   }
 `;
 
-const IntroStyle = styled.div`
-  margin-left: 10rem;
-  padding-top: 2rem;
+const IntroWrapper = styled.div`
+  width: 100%;
   text-align: right;
-  p{
-    font-size: 1.5rem;
+  margin-top: 5em;
+
+  & > p {
+    font-size: 1.5em;
     font-weight: 100;
+    line-height: 1.5em;
   }
-  h1 {
-    font-size: 6rem;
+
+  & > h1 {
+    font-size: 5em;
     font-weight: 900;
     letter-spacing: -0.1rem;
   }
@@ -104,53 +130,32 @@ const IntroStyle = styled.div`
     margin-left: 0rem;
     padding-top: 5rem;
     text-align: center;
-    p{
+    p {
       font-size: 1.5rem;
     }
 
-    h1{
+    h1 {
       font-size: 5rem;
     }
   }
-
 
   @media screen and (max-width: 414px) {
     // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
     margin-left: 0rem;
     text-align: center;
-    p{
+    p {
       font-size: 1.2rem;
     }
 
-    h1{
+    h1 {
       font-size: 4rem;
     }
   }
 `;
 
-const IntroContents = styled.div`
-  font-size: 1.5rem;
-  line-height: 2rem;
-  font-weight: 100;
-
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    width: 80vw;
-    font-size: 2rem;
-    line-height: 2.5rem;
-  }
-
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    width: 75vw;
-    font-size: 1.2rem;
-    line-height: 1.5rem;
-  }
-  
-`;
 
 const ScrollIconStyle = styled.div`
-  padding-top: 15rem;
+  padding-top: 15em;
   @keyframes float {
     0% {
       transform: translatey(0px);

--- a/pages/Main/MainWorks.tsx
+++ b/pages/Main/MainWorks.tsx
@@ -56,99 +56,211 @@ const MainWorks = () => {
 };
 
 const MainWorksWrapper = styled.div`
-  width: 65vw;
-  height: 80vh;
+  width: 1030px;
   display: flex;
-  flex-direction: row;
   justify-content: center;
-  align-items: flex-start;
-  margin: 10vh 0vh 20vh 0vh;
+  align-items: center;
+  padding-top: 15rem;
+  margin-bottom: 20rem;
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    margin: 10vh 0vh 10vh 0vh;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    width: 700px;
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    padding-top: 8rem;
+    width: 500px;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 400px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 400px;
+    margin-bottom: 10rem;
   }
 `;
 
 const MainWorksContents = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: flex-start;
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    align-items: center;
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 400px;
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 400px;
+  }
 `;
 
 const WorksTitle = styled.div`
+  width: 70%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
 
-  h1 {
+  & > h1 {
+    flex: 1;
     text-align: left;
-    font-size: 5rem;
+    font-size: 4.5em;
     letter-spacing: -7px;
   }
 
-  p {
-    width: 100%;
+  & > p {
     font-weight: 100;
-    margin-top: 2vh;
-    font-size: 1.5rem;
+    font-size: 1.5em;
     text-align: left;
   }
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    width: 100%;
-    justify-content: center;
-    align-items: center;
-
-    h1 {
-      text-align: center;
-      font-size: 4rem;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    & > h1 {
+      flex: 1;
+      text-align: left;
+      font-size: 2.8em;
       letter-spacing: -5px;
     }
 
-    p {
-      width: 100%;
-      margin: 3vh 0vh 3vh 0vh;
-      font-size: 2rem;
+    & > p {
+      font-weight: 100;
+      font-size: 1em;
+      text-align: left;
+    }
+  }
+
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    width: 100%;
+    align-items: center;
+    & > h1 {
+      flex: 1;
+      text-align: center;
+      font-size: 3.5em;
+      letter-spacing: -5px;
+    }
+
+    & > p {
+      font-weight: 100;
+      font-size: 1em;
+      letter-spacing: -1px;
+      text-align: left;
+    }
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 100%;
+    align-items: center;
+    & > h1 {
+      flex: 1;
+      text-align: center;
+      font-size: 3.5em;
+      letter-spacing: -5px;
+    }
+
+    & > p {
+      width: 90%;
+      font-weight: 100;
+      font-size: 1.5em;
+      letter-spacing: -1px;
       text-align: center;
     }
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    h1 {
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 100%;
+    align-items: center;
+    
+    & > h1 {
+      flex: 1;
       text-align: center;
-      font-size: 2.3rem;
-      letter-spacing: -2px;
+      font-size: 2.5em;
+      letter-spacing: -5px;
     }
 
-    p {
+    & > p {
+      width: 90%;
+      font-weight: 100;
+      font-size: 1.2em;
+      letter-spacing: -1px;
       text-align: center;
-      font-size: 1.2rem;
     }
   }
 `;
 
 const ScrollMenuWrapper = styled.div`
-  width: 80vw;
-  margin-left: -5vw;
+  width: 100%;
+  margin: 1em 0em 0em -3em;
   overflow-x: scroll;
-  margin-top: 5vh;
 
-  @media screen and (max-width: 820px) {
-    // iPad Air (820 * 1180) 이하의 기기에서 적용될 스타일
-    width: 80vw;
+  /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/
+  @media all and (min-width: 1024px) and (max-width: 1279px) {
+    img {
+      width: calc(100vw / 4);
+      height: calc(100vh / 5);
+    }
+
+    h1 {
+      font-size: 2em;
+    }
   }
 
-  @media screen and (max-width: 414px) {
-    // iPhone XR (414 * 896) 이하의 기기에서 적용될 스타일
-    width: 80vw;
+  /* 테블릿 가로 (해상도 768px ~ 1023px)*/
+  @media all and (min-width: 768px) and (max-width: 1023px) {
+    h1 {
+      font-size: 2em;
+    }
+  }
+
+  /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
+  @media all and (min-width: 480px) and (max-width: 767px) {
+    width: 100vw;
+    margin: 1em 0em 0em -3em;
+    img {
+      width: calc(100vw / 3);
+      height: calc(100vh / 7);
+    }
+
+    h1 {
+      font-size: 1.5em;
+    }
+  }
+
+  /* 모바일 세로 (해상도 ~ 479px)*/
+  @media all and (max-width: 479px) {
+    width: 100vw;
+    margin: 1em 0em 0em -3em;
+    img {
+      width: calc(100vw / 3);
+      height: calc(100vh / 8.5);
+    }
+
+    h1 {
+      font-size: 1.5em;
+    }
+
   }
 `;
 
 const StyledScrollMenu = styled(ScrollMenu)`
-  width: 100%;
+  width: 100%
 `;
 
 export default MainWorks;


### PR DESCRIPTION
## Summary
- Main 페이지의 CSS 스타일의 리팩토링을 리팩토링하였습니다.
- Projects 상세보기 페이지와 동일한 Media Query 기준을 적용하였습니다.

## Descriptions
- 다음과 같은 화면 너비 기준으로 미디어 쿼리를 작성하였습니다.
  - 1280px 이상 - 데스크탑 기준
  - 1024px ~ 1279px - 노트북 & 태블릿 가로 화면 기준
  - 768px ~ 1023px - 태블릿 가로 화면 기준
  - 480px ~ 767px - 모바일 가로 & 태블릿 세로 화면 기준
  - ~ 479px - 기타 모바일 세로 화면 기준
- 전반적인 폰트와 이미지 크기를 조정하였습니다. 
  - 이 기준 역시 LGTM입니다.
- 자세한 변경사항은 첨부한 이미지를 통해 확인해주세요.

## Images
### 1280px 이상
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/ce0a60d2-fcee-4497-a091-b3a24575f506" width="300"/>

### 1024px ~ 1279px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/3afc3982-f47f-42e1-973f-107e7e020c6c" width="300"/>

### 768px ~ 1023px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/dc80c422-e490-4497-abda-0a1c52e30528" width="300"/>

### 480px ~ 767px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/5e0d07b9-1f5e-426f-b95f-a69ae36387cd" width="300"/>

### ~ 479px
<img src="https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/e7d65d04-7c96-4f4e-970b-f139e297e749" width="300"/>