### PR TITLE
[FIX] Project List 항목 누락 이슈 해결

### DIFF
--- a/pages/Projects/Projects.tsx
+++ b/pages/Projects/Projects.tsx
@@ -15,11 +15,12 @@ const Projects = () => {
       if (!apiResult) return;
 
       let projectDataSet = new Map<string, API.ProjectListItem[]>([
-            ["android", new Array<API.ProjectListItem>],
-            ["etc", new Array<API.ProjectListItem>],
-            ["repair", new Array<API.ProjectListItem>],
-            ["web", new Array<API.ProjectListItem>]
-        ]);
+        ["android", new Array<API.ProjectListItem>],
+        ["etc", new Array<API.ProjectListItem>],
+        ["repair", new Array<API.ProjectListItem>],
+        ["web", new Array<API.ProjectListItem>]
+      ]);
+
       apiResult.data.map((projectData: API.ProjectListItem) => {
         projectDataSet.set(projectData.data.category, [...projectDataSet.get(projectData.data.category)!, projectData])
       });

--- a/pages/Projects/Projects.tsx
+++ b/pages/Projects/Projects.tsx
@@ -13,22 +13,21 @@ const Projects = () => {
   useEffect(() => {
     API.getProjectList().then((apiResult: any) => {
       if (!apiResult) return;
+
+      let projectDataSet = new Map<string, API.ProjectListItem[]>([
+            ["android", new Array<API.ProjectListItem>],
+            ["etc", new Array<API.ProjectListItem>],
+            ["repair", new Array<API.ProjectListItem>],
+            ["web", new Array<API.ProjectListItem>]
+        ]);
       apiResult.data.map((projectData: API.ProjectListItem) => {
-        switch(projectData.data.category) {
-          case 'android':
-            setAndroidProjectList([...androidProjectList, projectData]);
-            return;
-          case 'web':
-            setWebProjectList([...webProjectList, projectData]);
-            return;
-          case 'repair':
-            setSelfRepairList([...selfRepairList, projectData]);
-            return;
-          default:
-            setEtcProjectList([...etcProjectList, projectData]);
-            return;
-        }
-      })
+        projectDataSet.set(projectData.data.category, [...projectDataSet.get(projectData.data.category)!, projectData])
+      });
+
+      setAndroidProjectList(projectDataSet.get("android")!);
+      setEtcProjectList(projectDataSet.get("etc")!);
+      setSelfRepairList(projectDataSet.get("repair")!);
+      setWebProjectList(projectDataSet.get("web")!);
     });
   }, []);
 


### PR DESCRIPTION
## Summary
Project List에서 항목이 누락되던 이슈를 해결하였습니다.

## Description
- 기존 코드의 경우, 각 Category별 List가 State로 선언되어있고, API에서 불러온 데이터를 map으로 선회하며 List State에 Append 하도록 되어있었습니다.
- 여기서, 비동기로 동작하는 State의 특성으로 인해 새 데이터가 Append되기 직전 빈 List State에 반복해서 Append 되는 현상이 일어나, 최종적으로는 가장 마지막 항목만이 유일하게 List에 포함되는 문제가 원인이었습니다.
- `useEffect` 내에서 임시 List를 생성하고, API에서 불러온 데이터를 선회하며 이 임시 List에 데이터를 Append한 뒤, 최종적으로 1회만 List State에 지정하는 방식으로 해결하였습니다.