### PR TITLE
[FIX] ProjectList 간격 조정

### DIFF
--- a/pages/Projects/ProjectSection.tsx
+++ b/pages/Projects/ProjectSection.tsx
@@ -20,7 +20,7 @@ const ProjectSection = (props: Props) => {
 
 const SectionWrapper = styled.div`
   width: 70vw;
-  padding: 128px 0 128px 0;
+  padding-top: 96px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -83,6 +83,7 @@ const SectionWrapper = styled.div`
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
   @media all and (min-width:480px) and (max-width:767px) {
+    padding: 64px 0 64px 0;
     & > div {
       width: 400px;
     }
@@ -102,6 +103,7 @@ const SectionWrapper = styled.div`
 
   /* 모바일 세로 (해상도 ~ 479px)*/ 
   @media all and (max-width:479px) {
+    padding: 64px 0 64px 0;
     & > div {
       width: 360px;
     }

--- a/pages/Projects/ProjectSection.tsx
+++ b/pages/Projects/ProjectSection.tsx
@@ -83,7 +83,7 @@ const SectionWrapper = styled.div`
 
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
   @media all and (min-width:480px) and (max-width:767px) {
-    padding: 64px 0 64px 0;
+    padding-top: 64px;
     & > div {
       width: 400px;
     }
@@ -103,7 +103,7 @@ const SectionWrapper = styled.div`
 
   /* 모바일 세로 (해상도 ~ 479px)*/ 
   @media all and (max-width:479px) {
-    padding: 64px 0 64px 0;
+    padding-top: 64px;
     & > div {
       width: 360px;
     }

--- a/pages/Projects/ProjectSection.tsx
+++ b/pages/Projects/ProjectSection.tsx
@@ -27,7 +27,7 @@ const SectionWrapper = styled.div`
 
   @media all and (min-width: 1280px) {
     & > div {
-      width: 1400px;
+      width: 1030px;
     }
     
     h1 {
@@ -46,7 +46,7 @@ const SectionWrapper = styled.div`
   /* 노트북 & 테블릿 가로 (해상도 1024px ~ 1279px)*/ 
   @media all and (min-width:1024px) and (max-width:1279px) {
     & > div {
-      width: 1024px;
+      width: 700px;
     }
     
     h1 {
@@ -65,7 +65,7 @@ const SectionWrapper = styled.div`
   /* 테블릿 가로 (해상도 768px ~ 1023px)*/ 
   @media all and (min-width:768px) and (max-width:1023px) {
     & > div {
-      width: 768px;
+      width: 500px;
     }
     
     h1 {
@@ -84,7 +84,7 @@ const SectionWrapper = styled.div`
   /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/ 
   @media all and (min-width:480px) and (max-width:767px) {
     & > div {
-      width: 480px;
+      width: 400px;
     }
     
     h1 {
@@ -103,7 +103,7 @@ const SectionWrapper = styled.div`
   /* 모바일 세로 (해상도 ~ 479px)*/ 
   @media all and (max-width:479px) {
     & > div {
-      width: 360px;
+      width: 400px;
     }
     
     h1 {

--- a/pages/Projects/ProjectSection.tsx
+++ b/pages/Projects/ProjectSection.tsx
@@ -20,7 +20,7 @@ const ProjectSection = (props: Props) => {
 
 const SectionWrapper = styled.div`
   width: 70vw;
-  height: 100vh;
+  padding: 128px 0 128px 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -103,7 +103,7 @@ const SectionWrapper = styled.div`
   /* 모바일 세로 (해상도 ~ 479px)*/ 
   @media all and (max-width:479px) {
     & > div {
-      width: 400px;
+      width: 360px;
     }
     
     h1 {

--- a/pages/Projects/Projects.tsx
+++ b/pages/Projects/Projects.tsx
@@ -60,6 +60,7 @@ const Projects = () => {
 
 const ProjectWrapper = styled.div`
   font-family: "Noto Sans KR";
+  margin-top: 128px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
프로젝트 페이지에서 리스트들의 간격을 조정했습니다.
## Description
- ProjectSection의 width 값 조정
- ProjectSection에서 padding-top 적용 (96px, width 768px 미만 -> 64px)
- Project 페이지에서 margin-top 적용 (128px)
## ScreenShots
해상도 : 1920x1080
<img width="1059" alt="Screenshot 2023-08-02 at 12 28 58 AM" src="https://github.com/DefCon-Apps/DefCon-FE/assets/10252712/3387e964-74bc-4ef6-82a6-3cab5d8892b5">
해상도 : iPhone 12 Pro
<img width="338" alt="Screenshot 2023-08-02 at 12 39 48 AM" src="https://github.com/DefCon-Apps/DefCon-FE/assets/10252712/7ea2ecc1-5236-414b-9093-70170ed3f789">

