### PR TITLE
[FIX] ProjectList Reverse

### DIFF
--- a/pages/projects/Projects.tsx
+++ b/pages/projects/Projects.tsx
@@ -25,10 +25,10 @@ const Projects = () => {
         projectDataSet.set(projectData.data.category, [...projectDataSet.get(projectData.data.category)!, projectData])
       });
 
-      setAndroidProjectList(projectDataSet.get("android")!);
-      setEtcProjectList(projectDataSet.get("etc")!);
-      setSelfRepairList(projectDataSet.get("repair")!);
-      setWebProjectList(projectDataSet.get("web")!);
+      setAndroidProjectList(projectDataSet.get("android")!.reverse());
+      setEtcProjectList(projectDataSet.get("etc")!.reverse());
+      setSelfRepairList(projectDataSet.get("repair")!.reverse());
+      setWebProjectList(projectDataSet.get("web")!.reverse());
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- #142 Issues에 주어져있던 태스크 중 Projects List를 최신순으로 보여주기 위해 반전하는 것이 누락되어 작업하였습니다.

## Descriptions
- pages/projects/Projects.tsx에서 비동기 요청으로 요청한 list 형태의 자료를 setState 할 때 reverse() 메소드를 활용하여 반전된 상태로 변경되도록 하였습니다.

## Images
- 추후에 등록된 TAXI METER 및 MILICENSE가 먼저 표시됩니다.
![image](https://github.com/DefCon-Apps/DefCon-FE/assets/47844901/cd47781d-d2f5-4c96-9cd0-94ebd9359919)
